### PR TITLE
REL,API: 0.2.0 Start branch 0.2.0. Only process .ipynb files unless option -f is used

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,0 +1,20 @@
+0.1.x branch
+------------
+Maintained by Florian Rathgeber
+
+* https://github.com/kynan/nbstripout
+
+0.1.0:
+  * Based on Min RK's orginal but supports multiple versions of
+    IPython/Jupyter and also strips the execution count.
+
+
+0.2.x branch
+------------
+Maintained by Michael McNeil Forbes
+
+* https://github.com/mforbes/nbstripout
+
+0.2.0:
+  * Only process .ipynb files unless -f flag is used
+  * Will process multiple files

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,0 +1,20 @@
+Copyright (c) 2015 Min RK, Florian Rathgeber, Michael McNeil Forbes
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/README.rst
+++ b/README.rst
@@ -15,9 +15,13 @@ Based on https://gist.github.com/minrk/6176788.
 Usage
 =====
 
-Strip output from IPython / Jupyter notebook (modifies the file in-place): ::
+Strip output from IPython / Jupyter notebook (modifies the files in-place): ::
 
-    nbstripout FILE.ipynb
+    nbstripout FILE.ipynb [FILE2.ipynb ...]
+
+Force processing of non ``.ipynb`` files:
+
+    nbstripout -f FILE.ipynb.bak
 
 Use as part of a shell pipeline: ::
 
@@ -44,3 +48,15 @@ Set up a git filter using nbstripout as follows: ::
 Create a file ``.gitattributes`` or ``.git/info/attributes`` with: ::
 
     *.ipynb filter=nbstripout
+
+Mercurial usage
+===============
+
+Mercurial does not have the equivalent of smudge filters.  One can use
+an encode/decode hook but this has some issues.  An alternative
+solution is to provide a set of commands that first run `nbstripout`,
+then perform there operations.  This is the approach of the
+[`mmf-setup` package](https://pypi.python.org/pypi/mmf-setup) which
+uses the 0.2.x branch of `nbstripout`:
+
+* http://bitbucket.org/mforbes/mmf_setup

--- a/setup.py
+++ b/setup.py
@@ -18,6 +18,8 @@ setup(name='nbstripout',
       maintainer_email='michael.forbes+python@gmail.com',
       url='https://github.com/mforbes/nbstripout',
 
+      license="License :: OSI Approved :: MIT License",
+
       description='Strips outputs from Jupyter and IPython notebooks',
       long_description=long_description,
       py_modules=['nbstripout'],
@@ -25,4 +27,13 @@ setup(name='nbstripout',
           'console_scripts': [
               'nbstripout = nbstripout:main'
           ]
-      })
+      },
+
+      classifiers=[
+          "Development Status :: 4 - Beta",
+          "Environment :: Other Environment",
+          "Framework :: IPython",
+          "Intended Audience :: Developers",
+          "Programming Language :: Python",
+          "Topic :: Software Development :: Version Control",
+      ])

--- a/setup.py
+++ b/setup.py
@@ -4,12 +4,20 @@ with open('README.rst') as f:
     long_description = f.read()
 
 setup(name='nbstripout',
-      version='0.1.0',
+      version='0.2.0',
       author='Min RK',
       author_email='benjaminrk@gmail.com',
-      maintainer='Florian Rathgeber',
-      maintainer_email='florian.rathgeber@gmail.com',
-      url='https://github.com/kynan/nbstripout',
+
+      # 0.1 branch
+      # maintainer='Florian Rathgeber',
+      # maintainer_email='florian.rathgeber@gmail.com',
+      # url='https://github.com/kynan/nbstripout',
+
+      # 0.2 branch
+      maintainer='Michael McNeil Forbes',
+      maintainer_email='michael.forbes+python@gmail.com',
+      url='https://github.com/mforbes/nbstripout',
+
       description='Strips outputs from Jupyter and IPython notebooks',
       long_description=long_description,
       py_modules=['nbstripout'],


### PR DESCRIPTION
This is the version I uploaded to PyPI: [nbstripout==0.2.0](https://pypi.python.org/pypi/nbstripout/0.2.0).  I will only modify the `0.2.x` revisions and am happy to assign you as an owner or maintainer if you would like so you can upload changes.  I needed a few additions to get things working with my mercurial workflow:

- Processes multiple files.
- Ignores all files but .ipynb files by default.
- Added -f flag to force stripping other files.
- This is the start of the 0.2.x branch which is maintained for now
  in a separate fork.

This does change the default behaviour (which would process any file, but could throw errors if the file was not a notebook) so I have gone with a new minor revision number.