### PR TITLE
add Python 3 support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,3 +56,6 @@ docs/_build/
 
 # PyBuilder
 target/
+
+# tmp files
+*~

--- a/nbstripout.py
+++ b/nbstripout.py
@@ -57,8 +57,10 @@ from __future__ import print_function
 import codecs
 import io
 import sys
-# Use UTF8 writer for stdout (http://stackoverflow.com/a/1169209)
-sys.stdout = codecs.getwriter('utf8')(sys.stdout)
+
+if sys.version_info < (3, 0):
+    # Use UTF8 writer for stdout (http://stackoverflow.com/a/1169209)
+    sys.stdout = codecs.getwriter('utf8')(sys.stdout)
 
 __version__ = '0.2.4'
 


### PR DESCRIPTION
The cmd-line interface was working with Python3, but it was not running when nbstripout is installed and used with git gut under Linux (Ubuntu 14.04)