### PR TITLE
Git filter fails on windows as python outputs paths with '\\' instead…

### DIFF
--- a/nbstripout.py
+++ b/nbstripout.py
@@ -116,7 +116,8 @@ def install():
         print('Installation failed: not a git repository!', file=sys.stderr)
         sys.exit(1)
     check_call(['git', 'config', 'filter.nbstripout.clean', '%s %s' %
-               (sys.executable, path.abspath(__file__))])
+               (sys.executable.replace('\\', '/'),
+                path.abspath(__file__).replace('\\', '/'))])
     check_call(['git', 'config', 'filter.nbstripout.smudge', 'cat'])
     check_call(['git', 'config', 'filter.nbstripout.required', 'true'])
     attrfile = path.join(git_dir.decode(), 'info', 'attributes')


### PR DESCRIPTION
… of '/' when doing nbstripout install. Adding a simple replace command.

This fixes #18 