### PR TITLE
ENH: Resolves issue #17 providing a way to keep output in selected cells.

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -7,14 +7,10 @@ Maintained by Florian Rathgeber
 0.1.0:
   * Based on Min RK's orginal but supports multiple versions of
     IPython/Jupyter and also strips the execution count.
-
-
-0.2.x branch
-------------
-Maintained by Michael McNeil Forbes
-
-* https://github.com/mforbes/nbstripout
-
 0.2.0:
   * Only process .ipynb files unless -f flag is used
   * Will process multiple files
+0.2.7:
+  * If you set either the `"init_cell": true` or `"keep_output": true`
+    in the cell metadata, then these cells will not be stripped out.
+    The former works in conjunction with the `init_cell` nbextension.

--- a/README.rst
+++ b/README.rst
@@ -63,6 +63,30 @@ Show this help page: ::
 
     nbstripout --help
 
+Keeping some output
++++++++++++++++++++
+
+To mark special cells so that the output is not striped, set the
+``"keep_output": true`` metadata on the cell.  To do this, select the
+"Edit Metadata" Cell Toolbar, and then use the "Edit Metadata" button
+on the desired cell to enter something like::
+
+    {
+      "keep_output": true,
+    }
+
+Another use-case is to preserve initialization cells that might load
+customized CSS etc. critical for the display of the notebook.  To
+support this, we also keep output for cells with::
+
+    {
+      "init_cell": true,
+    }
+
+This is the same metadata used by the `init_cell nbextension`__.
+
+__ https://github.com/ipython-contrib/IPython-notebook-extensions/tree/master/nbextensions/usability/init_cell
+
 Manual filter installation
 ==========================
 

--- a/nbstripout.py
+++ b/nbstripout.py
@@ -112,6 +112,9 @@ def strip_output(nb):
     """strip the outputs from a notebook object"""
     nb.metadata.pop('signature', None)
     for cell in _cells(nb):
+        if (cell.metadata.get('init_cell') or cell.metadata.get('keep_output')):
+            # Leave these cells alone
+            continue
         if 'outputs' in cell:
             cell['outputs'] = []
         if 'prompt_number' in cell:

--- a/tests/test-metadata.t
+++ b/tests/test-metadata.t
@@ -1,0 +1,91 @@
+  $ cat ${TESTDIR}/test_metadata.ipynb | nbstripout
+  {
+   "cells": [
+    {
+     "cell_type": "markdown",
+     "metadata": {},
+     "source": [
+      "This notebook tests that cells with either `\"keep_output\": true` or `\"init_cell\": true` are not stripped."
+     ]
+    },
+    {
+     "cell_type": "code",
+     "execution_count": 1,
+     "metadata": {
+      "collapsed": false,
+      "init_cell": true
+     },
+     "outputs": [
+      {
+       "data": {
+        "text/plain": [
+         "2"
+        ]
+       },
+       "execution_count": 1,
+       "metadata": {},
+       "output_type": "execute_result"
+      }
+     ],
+     "source": [
+      "1+1 # This cell has `\"init_cell:\" true`"
+     ]
+    },
+    {
+     "cell_type": "code",
+     "execution_count": 2,
+     "metadata": {
+      "collapsed": false,
+      "keep_output": true
+     },
+     "outputs": [
+      {
+       "data": {
+        "text/plain": [
+         "4"
+        ]
+       },
+       "execution_count": 2,
+       "metadata": {},
+       "output_type": "execute_result"
+      }
+     ],
+     "source": [
+      "2+2 # This cell has `\"keep_output:\" true`"
+     ]
+    },
+    {
+     "cell_type": "code",
+     "execution_count": null,
+     "metadata": {
+      "collapsed": false
+     },
+     "outputs": [],
+     "source": [
+      "3+3"
+     ]
+    }
+   ],
+   "metadata": {
+    "celltoolbar": "Edit Metadata",
+    "kernelspec": {
+     "display_name": "Python 2",
+     "language": "python",
+     "name": "python2"
+    },
+    "language_info": {
+     "codemirror_mode": {
+      "name": "ipython",
+      "version": 2
+     },
+     "file_extension": ".py",
+     "mimetype": "text/x-python",
+     "name": "python",
+     "nbconvert_exporter": "python",
+     "pygments_lexer": "ipython2",
+     "version": "2.7.11"
+    }
+   },
+   "nbformat": 4,
+   "nbformat_minor": 0
+  }

--- a/tests/test-unicode.t
+++ b/tests/test-unicode.t
@@ -9,7 +9,7 @@
      },
      "outputs": [],
      "source": [
-      "print u\"äöü\""
+      "print u\\"\xc3\xa4\xc3\xb6\xc3\xbc\\"" (esc)
      ]
     }
    ],

--- a/tests/test-unicode.t
+++ b/tests/test-unicode.t
@@ -1,37 +1,37 @@
-$ cat test_unicode.ipynb | nbstripout
-@ {
-@  "cells": [
-@   {
-@    "cell_type": "code",
-@    "execution_count": null,
-@    "metadata": {
-@     "collapsed": false
-@    },
-@    "outputs": [],
-@    "source": [
-@     "print u\"äöü\""
-@    ]
-@   }
-@  ],
-@  "metadata": {
-@   "kernelspec": {
-@    "display_name": "Python 2",
-@    "language": "python",
-@    "name": "python2"
-@   },
-@   "language_info": {
-@    "codemirror_mode": {
-@     "name": "ipython",
-@     "version": 2
-@    },
-@    "file_extension": ".py",
-@    "mimetype": "text/x-python",
-@    "name": "python",
-@    "nbconvert_exporter": "python",
-@    "pygments_lexer": "ipython2",
-@    "version": "2.7.11"
-@   }
-@  },
-@  "nbformat": 4,
-@  "nbformat_minor": 0
-@ }
+  $ cat ${TESTDIR}/test_unicode.ipynb | nbstripout
+  {
+   "cells": [
+    {
+     "cell_type": "code",
+     "execution_count": null,
+     "metadata": {
+      "collapsed": false
+     },
+     "outputs": [],
+     "source": [
+      "print u\"äöü\""
+     ]
+    }
+   ],
+   "metadata": {
+    "kernelspec": {
+     "display_name": "Python 2",
+     "language": "python",
+     "name": "python2"
+    },
+    "language_info": {
+     "codemirror_mode": {
+      "name": "ipython",
+      "version": 2
+     },
+     "file_extension": ".py",
+     "mimetype": "text/x-python",
+     "name": "python",
+     "nbconvert_exporter": "python",
+     "pygments_lexer": "ipython2",
+     "version": "2.7.11"
+    }
+   },
+   "nbformat": 4,
+   "nbformat_minor": 0
+  }

--- a/tests/test_metadata.ipynb
+++ b/tests/test_metadata.ipynb
@@ -1,0 +1,101 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This notebook tests that cells with either `\"keep_output\": true` or `\"init_cell\": true` are not stripped."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {
+    "collapsed": false,
+    "init_cell": true
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "2"
+      ]
+     },
+     "execution_count": 1,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "1+1 # This cell has `\"init_cell:\" true`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {
+    "collapsed": false,
+    "keep_output": true
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "4"
+      ]
+     },
+     "execution_count": 2,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "2+2 # This cell has `\"keep_output:\" true`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "6"
+      ]
+     },
+     "execution_count": 3,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "3+3"
+   ]
+  }
+ ],
+ "metadata": {
+  "celltoolbar": "Edit Metadata",
+  "kernelspec": {
+   "display_name": "Python 2",
+   "language": "python",
+   "name": "python2"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 2
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython2",
+   "version": "2.7.11"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 0
+}


### PR DESCRIPTION
This PR provides a simple resolution to issue #17 of providing a mechanism for keep some cells output.  The approach is simply to leave alone cells with either of the following metadata:

**`"keep_output": true`**: This is a custom piece of metadata that can be used to resolve the issue.
 
In addition, we also respect the following:

**`"init_cell": true`**: This is used by the [`init_cell` nbextension](https://github.com/ipython-contrib/IPython-notebook-extensions/tree/master/nbextensions/usability/init_cell) to mark cells as initialization cells.  These cells are executed when the notebook is loaded.

## Rational

1.  The primary use case is a cell that loads CSS styling for a notebook, especially with MathJaX macro definitions. The output from this cell can be imperative for proper rendering of documentation for online viewing.
2. These cells are automatically executed in a consistent order, so they should not generate much noise - once they are committed, they should not change during regular execution of the notebook.
3. Other sorts of initialization cells will import modules for working, and will generally have very little output, again creating little noise.

## Limitations

1. We may want to provide a way for users to customize this so they can choose to ignore custom metadata.  This, however, requires more configuration control which I am not sure we want to implement right now.
2. One can easily imagine use-cases for initialization cells where saving the output is not desired.  Perhaps some way should be provided for disabling this behaviour.

## Additions

In addition the the previous functionality, this PR also updates the unicode test which was not being executed by `cram` (test lines need 2 blank spaces to indicate that they should be executed.)