### PR TITLE
Normalise cell output style

### DIFF
--- a/nbstripout.py
+++ b/nbstripout.py
@@ -133,6 +133,9 @@ def strip_output(nb):
             cell['prompt_number'] = None
         if 'execution_count' in cell:
             cell['execution_count'] = None
+        for output_style in ['collapsed', 'scrolled']:
+            if output_style in cell.metadata:
+                cell.metadata[output_style] = False
     return nb
 
 


### PR DESCRIPTION
This PR sets the "collapsed" and "scrolled" cell metadata attributes to false if they exist. This normalizes the cell output style, so that these changes which are easily introduced do not pollute version control.