### PR TITLE
added support for git diff

### DIFF
--- a/nbstripout.py
+++ b/nbstripout.py
@@ -78,7 +78,7 @@ Create a file ``.gitattributes`` or ``.git/info/attributes`` with: ::
     *.ipynb filter=nbstripout
 
 Apply the filter for git diff of *.ipynb
-   
+
    git config diff.ipynb.textconv '/path/to/nbstripout -t'
 
 In file ``.gitattributes`` or ``.git/info/attributes`` add: ::
@@ -175,16 +175,16 @@ def install(attrfile=None):
     check_call(['git', 'config', 'filter.nbstripout.smudge', 'cat'])
     check_call(['git', 'config', 'filter.nbstripout.required', 'true'])
     check_call(['git', 'config', 'diff.ipynb.textconv', 'nbstripout -t'])
-    
+
     if not attrfile:
         attrfile = path.join(git_dir.decode(), 'info', 'attributes')
-   
+
     # Check if there is already a filter for ipynb files
     filt_exists = False
     diff_exists = False
     if path.exists(attrfile):
         with open(attrfile, 'r') as f:
-            filt_exists = '*.ipynb filter' in f.read() 
+            filt_exists = '*.ipynb filter' in f.read()
             diff_exists = '*.ipynb diff' in f.read()
             if filt_exists and diff_exists:
                 return
@@ -205,10 +205,11 @@ def uninstall(attrfile=None):
     except CalledProcessError:
         print('Installation failed: not a git repository!', file=sys.stderr)
         sys.exit(1)
+
     call(['git', 'config', '--remove-section', 'filter.nbstripout'],
          stdout=open(devnull, 'w'), stderr=STDOUT)
 
-    call(['git', 'config', '--remove-section', 'diff.ipynb.textconv'],
+    call(['git', 'config', '--remove-section', 'diff.ipynb'],
          stdout=open(devnull, 'w'), stderr=STDOUT)
 
     if not attrfile:
@@ -252,7 +253,8 @@ def status(verbose=False):
         if verbose and 'git_dir' in locals():
             print('nbstripout is not installed in repository', git_dir)
         return 1
-    
+
+
 def main():
     parser = ArgumentParser(epilog=__doc__, formatter_class=RawDescriptionHelpFormatter)
     task = parser.add_mutually_exclusive_group()
@@ -273,7 +275,7 @@ def main():
                       help='Print version')
     parser.add_argument('--force', '-f', action='store_true',
                         help='Strip output also from files with non ipynb extension')
-    
+
     parser.add_argument('--textconv', '-t', action='store_true',
                         help='Prints stripped files to STDOUT')
 

--- a/nbstripout.py
+++ b/nbstripout.py
@@ -76,6 +76,14 @@ Set up a git filter using nbstripout as follows: ::
 Create a file ``.gitattributes`` or ``.git/info/attributes`` with: ::
 
     *.ipynb filter=nbstripout
+
+Apply the filter for git diff of *.ipynb
+   
+   git config diff.ipynb.textconv '/path/to/nbstripout -t'
+
+In file ``.gitattributes`` or ``.git/info/attributes`` add: ::
+
+    *.ipynb diff=ipynb
 """
 
 from __future__ import print_function
@@ -166,15 +174,26 @@ def install(attrfile=None):
                 path.abspath(__file__).replace('\\', '/'))])
     check_call(['git', 'config', 'filter.nbstripout.smudge', 'cat'])
     check_call(['git', 'config', 'filter.nbstripout.required', 'true'])
+    check_call(['git', 'config', 'diff.ipynb.textconv', 'nbstripout -t'])
+    
     if not attrfile:
         attrfile = path.join(git_dir.decode(), 'info', 'attributes')
+   
     # Check if there is already a filter for ipynb files
+    filt_exists = False
+    diff_exists = False
     if path.exists(attrfile):
         with open(attrfile, 'r') as f:
-            if '*.ipynb filter' in f.read():
+            filt_exists = '*.ipynb filter' in f.read() 
+            diff_exists = '*.ipynb diff' in f.read()
+            if filt_exists and diff_exists:
                 return
+
     with open(attrfile, 'a') as f:
-        print(('\n' if f.tell() else '') + '*.ipynb filter=nbstripout', file=f)
+        if not filt_exists:
+            print(('\n' if f.tell() else '') + '*.ipynb filter=nbstripout', file=f)
+        if not diff_exists:
+            print(('\n' if f.tell() else '') + '*.ipynb diff=ipynb', file=f)
 
 
 def uninstall(attrfile=None):
@@ -188,12 +207,16 @@ def uninstall(attrfile=None):
         sys.exit(1)
     call(['git', 'config', '--remove-section', 'filter.nbstripout'],
          stdout=open(devnull, 'w'), stderr=STDOUT)
+
+    call(['git', 'config', '--remove-section', 'diff.ipynb.textconv'],
+         stdout=open(devnull, 'w'), stderr=STDOUT)
+
     if not attrfile:
         attrfile = path.join(git_dir.decode(), 'info', 'attributes')
     # Check if there is a filter for ipynb files
     if path.exists(attrfile):
         with open(attrfile, 'r+') as f:
-            lines = [l for l in f if not l.startswith('*.ipynb filter')]
+            lines = [l for l in f if not (l.startswith('*.ipynb filter') or l.startswith('*.ipynb diff'))]
             f.seek(0)
             f.write(''.join(lines))
             f.truncate()
@@ -208,7 +231,9 @@ def status(verbose=False):
         clean = check_output(['git', 'config', 'filter.nbstripout.clean']).strip()
         smudge = check_output(['git', 'config', 'filter.nbstripout.smudge']).strip()
         required = check_output(['git', 'config', 'filter.nbstripout.required']).strip()
+        diff = check_output(['git', 'config', 'diff.ipynb.textconv']).strip()
         attributes = check_output(['git', 'check-attr', 'filter', '--', '*.ipynb']).strip()
+        diff_attributes = check_output(['git', 'check-attr', 'diff', '--', '*.ipynb']).strip()
         if attributes.endswith(b'unspecified'):
             if verbose:
                 print('nbstripout is not installed in repository', git_dir)
@@ -219,14 +244,15 @@ def status(verbose=False):
             print('  clean =', clean)
             print('  smudge =', smudge)
             print('  required =', required)
+            print('  diff=', diff)
             print('\nAttributes:\n ', attributes)
+            print('\nDiff Attributes:\n ', diff_attributes)
         return 0
     except CalledProcessError:
         if verbose and 'git_dir' in locals():
             print('nbstripout is not installed in repository', git_dir)
         return 1
-
-
+    
 def main():
     parser = ArgumentParser(epilog=__doc__, formatter_class=RawDescriptionHelpFormatter)
     task = parser.add_mutually_exclusive_group()
@@ -247,6 +273,10 @@ def main():
                       help='Print version')
     parser.add_argument('--force', '-f', action='store_true',
                         help='Strip output also from files with non ipynb extension')
+    
+    parser.add_argument('--textconv', '-t', action='store_true',
+                        help='Prints stripped files to STDOUT')
+
     parser.add_argument('files', nargs='*', help='Files to strip output from')
     args = parser.parse_args()
 
@@ -269,12 +299,16 @@ def main():
             with io.open(filename, 'r', encoding='utf8') as f:
                 nb = read(f, as_version=NO_CONVERT)
             nb = strip_output(nb)
-            with io.open(filename, 'w', encoding='utf8') as f:
-                write(nb, f)
+            if args.textconv:
+                write(nb, output_stream)
+            else:
+                with io.open(filename, 'w', encoding='utf8') as f:
+                    write(nb, f)
         except Exception:
             # Ignore exceptions for non-notebook files.
             print("Could not strip '{}'".format(filename))
             raise
+
     if not args.files:
         write(strip_output(read(input_stream, as_version=NO_CONVERT)), output_stream)
 

--- a/tests/test-diff.t
+++ b/tests/test-diff.t
@@ -1,8 +1,8 @@
   $ diff <(${NBSTRIPOUT_EXE:-nbstripout} -t ${TESTDIR}/test_diff.ipynb) <(${NBSTRIPOUT_EXE:-nbstripout} -t ${TESTDIR}/test_diff_output.ipynb)
   $ diff <(${NBSTRIPOUT_EXE:-nbstripout} -t ${TESTDIR}/test_diff.ipynb) <(${NBSTRIPOUT_EXE:-nbstripout} -t ${TESTDIR}/test_diff_output.ipynb)
   9c9
-  <     "print u\"äöü\""
+  <     "print(\"aou\")"
   ---
-  >     "print u\"äöü now it is different \""
+  >     "print(\"aou now it is different\")"
 
   

--- a/tests/test-diff.t
+++ b/tests/test-diff.t
@@ -1,6 +1,7 @@
-  $ diff <(${NBSTRIPOUT_EXE:-nbstripout} -t ${TESTDIR}/test_diff.ipynb) <(${NBSTRIPOUT_EXE:-nbstripout} -t ${TESTDIR}/test_diff_output.ipynb)
-  $ diff <(${NBSTRIPOUT_EXE:-nbstripout} -t ${TESTDIR}/test_diff.ipynb) <(${NBSTRIPOUT_EXE:-nbstripout} -t ${TESTDIR}/test_diff_output.ipynb)
-  9c9
+  $ bash -c "diff <( ${NBSTRIPOUT_EXE:-nbstripout} -t ${TESTDIR}/test_diff.ipynb ) <( ${NBSTRIPOUT_EXE:-nbstripout} -t ${TESTDIR}/test_diff_output.ipynb )"
+  $ bash -c "diff <( ${NBSTRIPOUT_EXE:-nbstripout} -t ${TESTDIR}/test_diff.ipynb ) <( ${NBSTRIPOUT_EXE:-nbstripout} -t ${TESTDIR}/test_diff_different.ipynb )"
+  (.*) (re)
   <     "print(\"aou\")"
   ---
-  >     "print(\"aou now it is different\")"
+  (.*\"print\(\\\"aou now it is different\\\"\)\") (re)
+  [1]

--- a/tests/test-diff.t
+++ b/tests/test-diff.t
@@ -4,7 +4,3 @@
   <     "print(\"aou\")"
   ---
   >     "print(\"aou now it is different\")"
-
-  
-
-  

--- a/tests/test-diff.t
+++ b/tests/test-diff.t
@@ -1,0 +1,8 @@
+  $ diff <(${NBSTRIPOUT_EXE:-nbstripout} -t ${TESTDIR}/test_diff.ipynb) <(${NBSTRIPOUT_EXE:-nbstripout} -t ${TESTDIR}/test_diff_output.ipynb)
+  $ diff <(${NBSTRIPOUT_EXE:-nbstripout} -t ${TESTDIR}/test_diff.ipynb) <(${NBSTRIPOUT_EXE:-nbstripout} -t ${TESTDIR}/test_diff_output.ipynb)
+  9c9
+  <     "print u\"äöü\""
+  ---
+  >     "print u\"äöü now it is different \""
+
+  

--- a/tests/test-git.t
+++ b/tests/test-git.t
@@ -6,8 +6,26 @@
   [1]
   $ nbstripout --install
   $ nbstripout --is-installed
+  $ git diff --no-ext-diff --unified=0 --exit-code -a --no-prefix ${TESTDIR}/test_diff.ipynb ${TESTDIR}/test_diff_output.ipynb 
+  [1]
+  $ git diff ${TESTDIR}/test_diff.ipynb ${TESTDIR}/test_diff_different.ipynb 
+  (diff --git.*) (re)
+  (index .*) (re)
+  (--- .*test_diff.ipynb) (re)
+  (\+\+\+ .*test_diff_different.ipynb) (re)
+  @@ -6,7 +6,7 @@
+      "metadata": {},
+      "outputs": [],
+      "source": [
+  -    "print(\"aou\")"
+  +    "print(\"aou now it is different\")"
+      ]
+     }
+    ],
+  [1]
   $ nbstripout --uninstall
   $ nbstripout --is-installed
   [1]
   $ cat .git/info/attributes
   *.txt text
+  

--- a/tests/test_diff.ipynb
+++ b/tests/test_diff.ipynb
@@ -8,7 +8,7 @@
    },
    "outputs": [],
    "source": [
-    "print u\"äöü\""
+    "print(\"aou\")"
    ]
   }
  ],

--- a/tests/test_diff.ipynb
+++ b/tests/test_diff.ipynb
@@ -1,0 +1,36 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "print u\"äöü\""
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 2",
+   "language": "python",
+   "name": "python2"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 2
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython2",
+   "version": "2.7.11"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 0
+}

--- a/tests/test_diff_different.ipynb
+++ b/tests/test_diff_different.ipynb
@@ -1,0 +1,44 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "äöü\n b stuff"
+     ]
+    }
+   ],
+   "source": [
+    "print u\"äöü now it is different \""
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 2",
+   "language": "python",
+   "name": "python2"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 2
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython2",
+   "version": "2.7.11"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 0
+}

--- a/tests/test_diff_different.ipynb
+++ b/tests/test_diff_different.ipynb
@@ -11,12 +11,12 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "äöü\n b stuff"
+      "aou now it is different\n"
      ]
     }
    ],
    "source": [
-    "print u\"äöü now it is different \""
+    "print(\"aou now it is different\")"
    ]
   }
  ],

--- a/tests/test_diff_output.ipynb
+++ b/tests/test_diff_output.ipynb
@@ -11,12 +11,12 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "äöü\n b stuff"
+      "aou\n"
      ]
     }
    ],
    "source": [
-    "print u\"äöü\""
+    "print(\"aou\")"
    ]
   }
  ],

--- a/tests/test_diff_output.ipynb
+++ b/tests/test_diff_output.ipynb
@@ -1,0 +1,44 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "äöü\n b stuff"
+     ]
+    }
+   ],
+   "source": [
+    "print u\"äöü\""
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 2",
+   "language": "python",
+   "name": "python2"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 2
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython2",
+   "version": "2.7.11"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 0
+}


### PR DESCRIPTION
This patch ensures that git diff makes a diff of the files after applying nbstripout.

I have also created a test, but I'm not sure about a couple things as I have never used travis, so I have included it here in hopes that someone can help me make it work.

I modified `test-git.t` as follows.
```
$ git init foobar
  Initialized empty Git repository in .* (re)
  $ cd foobar
  $ echo -n "*.txt text" >> .git/info/attributes
  $ nbstripout --is-installed
  [1]
  $ nbstripout --install
  $ nbstripout --is-installed
  $ git diff --no-ext-diff --unified=0 --exit-code -a --no-prefix ${TESTDIR}/test_diff.ipynb ${TESTDIR}/test_diff_output.ipynb 
  $ git diff ${TESTDIR}/test_diff.ipynb ${TESTDIR}/test_diff_different.ipynb 
  diff --git a/home/utsekaj42/sandbox/nbstripout/tests/test_diff.ipynb b/home/utsekaj42/sandbox/nbstripout/tests/test_diff_different.ipynb
  index e397b74..786bca5 100644
  --- a/home/utsekaj42/sandbox/nbstripout/tests/test_diff.ipynb
  +++ b/home/utsekaj42/sandbox/nbstripout/tests/test_diff_different.ipynb
  @@ -6,7 +6,7 @@
      "metadata": {},
      "outputs": [],
      "source": [
  -    "print u\"äöü\""
  +    "print u\"äöü now it is different \""
      ]
     }
    ],

  $ nbstripout --uninstall
  $ nbstripout --is-installed
  [1]
  $ cat .git/info/attributes
  *.txt text`
```