### PR TITLE
Use NBSTRIPOUT_EXE in test-git.t

### DIFF
--- a/tests/test-git.t
+++ b/tests/test-git.t
@@ -2,12 +2,12 @@
   Initialized empty Git repository in .* (re)
   $ cd foobar
   $ echo -n "*.txt text" >> .git/info/attributes
-  $ nbstripout --is-installed
+  $ ${NBSTRIPOUT_EXE:-nbstripout} --is-installed
   [1]
-  $ nbstripout --install
-  $ nbstripout --is-installed
-  $ nbstripout --uninstall
-  $ nbstripout --is-installed
+  $ ${NBSTRIPOUT_EXE:-nbstripout} --install
+  $ ${NBSTRIPOUT_EXE:-nbstripout} --is-installed
+  $ ${NBSTRIPOUT_EXE:-nbstripout} --uninstall
+  $ ${NBSTRIPOUT_EXE:-nbstripout} --is-installed
   [1]
   $ cat .git/info/attributes
   *.txt text


### PR DESCRIPTION
Other tests support `NBSTRIPOUT_EXE` environment variable to choose the `nbstripout` executable. Should `test-git.t` also support that? Now `test-git.t` test fails even if I set the executable with `NBSTRIPOUT_EXE`. I need to add `nbstripout` executable to my path instead.