### PR TITLE
Add options to keep output and/or execution counts

### DIFF
--- a/nbstripout.py
+++ b/nbstripout.py
@@ -149,25 +149,28 @@ def strip_output(nb, keep_output, keep_count):
 
     for cell in _cells(nb):
 
+        keep_output_this_cell = keep_output
+
         # Keep the output for these cells, but strip count and metadata
-        if (cell.metadata.get('init_cell') or cell.metadata.get('keep_output')):
-            keep_output = True
+        if cell.metadata.get('init_cell') or cell.metadata.get('keep_output'):
+            keep_output_this_cell = True
 
         # Remove the outputs, unless directed otherwise
         if 'outputs' in cell:
 
-            # Default behavior strips outputs. Since there are no outputs,
+            # Default behavior strips outputs. With all outputs stripped,
             # there are no counts to keep and keep_count is ignored.
-            if not keep_output:
+            if not keep_output_this_cell:
                 cell['outputs'] = []
 
-            # If keep_out, but not keep_count, strip the counts from the output.
-            if keep_output and not keep_count:
+            # If keep_output_this_cell, but not keep_count, strip the counts
+            # from the output.
+            if keep_output_this_cell and not keep_count:
                 for output in cell['outputs']:
                     if 'execution_count' in output:
                         output['execution_count'] = None
 
-            # If keep_out and keep_count, do nothing.
+            # If keep_output_this_cell and keep_count, do nothing.
 
         # Remove the prompt_number/execution_count, unless directed otherwise
         if 'prompt_number' in cell and not keep_count:

--- a/nbstripout.py
+++ b/nbstripout.py
@@ -330,7 +330,7 @@ def main():
         try:
             with io.open(filename, 'r', encoding='utf8') as f:
                 nb = read(f, as_version=NO_CONVERT)
-            nb = strip_output(nb)
+            nb = strip_output(nb, args.keep_output, args.keep_count)
             if args.textconv:
                 write(nb, output_stream)
             else:

--- a/nbstripout.py
+++ b/nbstripout.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python
 """
 Strip output from Jupyter and IPython notebooks
 ===============================================
@@ -149,9 +149,9 @@ def strip_output(nb, keep_output, keep_count):
 
     for cell in _cells(nb):
 
+        # Keep the output for these cells, but strip count and metadata
         if (cell.metadata.get('init_cell') or cell.metadata.get('keep_output')):
-            # Leave these cells alone
-            continue
+            keep_output = True
 
         # Remove the outputs, unless directed otherwise
         if 'outputs' in cell:

--- a/nbstripout.py
+++ b/nbstripout.py
@@ -146,8 +146,13 @@ def strip_output(nb, keep_output, keep_count):
             continue
 
         # remove the outputs, unless directed otherwise
-        if 'outputs' in cell and not keep_output:
-            cell['outputs'] = []
+        if 'outputs' in cell:
+            if not keep_output:
+                cell['outputs'] = []
+            else:
+                for output in cell['outputs']:
+                    if 'execution_count' in output:
+                        output['execution_count'] = None
 
         # remove the prompt_number/execution_count, unless directed otherwise
         if 'prompt_number' in cell and not keep_count:

--- a/nbstripout.py
+++ b/nbstripout.py
@@ -145,22 +145,29 @@ def strip_output(nb, keep_output, keep_count):
             # Leave these cells alone
             continue
 
-        # remove the outputs, unless directed otherwise
+        # Remove the outputs, unless directed otherwise
         if 'outputs' in cell:
-            if not keep_output:
+
+            # Default behavior strips outputs. Since there are no outputs,
+            # there are no counts to keep and keep_count is ignored.
+            if not keep_out:
                 cell['outputs'] = []
-            else:
+
+            # If keep_out, but not keep_count, strip the counts from the output.
+            if keep_out and not keep_count:
                 for output in cell['outputs']:
                     if 'execution_count' in output:
                         output['execution_count'] = None
 
-        # remove the prompt_number/execution_count, unless directed otherwise
+            # If keep_out and keep_count, do nothing.
+
+        # Remove the prompt_number/execution_count, unless directed otherwise
         if 'prompt_number' in cell and not keep_count:
             cell['prompt_number'] = None
         if 'execution_count' in cell and not keep_count:
             cell['execution_count'] = None
 
-        # always remove this metadata
+        # Always remove this metadata
         for output_style in ['collapsed', 'scrolled']:
             if output_style in cell.metadata:
                 cell.metadata[output_style] = False
@@ -258,10 +265,10 @@ def main():
                       help='Check if nbstripout is installed in current repository')
     task.add_argument('--status', action='store_true',
                       help='Print status of nbstripout installation in current repository and configuration summary if installed')
-    parser.add_argument('-c', '--count', action='store_true', help="""
-                        Do not strip the execution count/prompt number""")
-    parser.add_argument('-o', '--output', action='store_true', help="""
-                        Do not strip the output""")
+    parser.add_argument('--keep-count', action='store_true',
+                        help='Do not strip the execution count/prompt number')
+    parser.add_argument('--keep-output', action='store_true',
+                        help='Do not strip output')
     parser.add_argument('--attributes', metavar='FILEPATH', help="""Attributes
         file to add the filter to (in combination with --install/--uninstall),
         defaults to .git/info/attributes""")
@@ -299,7 +306,7 @@ def main():
             raise
     if not args.files:
         nb = strip_output(read(input_stream, as_version=NO_CONVERT),
-                          args.output, args.count)
+                          args.keep_output, args.keep_count)
         write(nb, output_stream)
 
 

--- a/tests/test-keep-count.t
+++ b/tests/test-keep-count.t
@@ -65,23 +65,23 @@
    "metadata": {
     "celltoolbar": "Edit Metadata",
     "kernelspec": {
-     "display_name": "Python 3",
+     "display_name": "Python 2",
      "language": "python",
-     "name": "python3"
+     "name": "python2"
     },
     "language_info": {
      "codemirror_mode": {
       "name": "ipython",
-      "version": 3
+      "version": 2
      },
      "file_extension": ".py",
      "mimetype": "text/x-python",
      "name": "python",
      "nbconvert_exporter": "python",
-     "pygments_lexer": "ipython3",
-     "version": "3.5.2"
+     "pygments_lexer": "ipython2",
+     "version": "2.7.11"
     }
    },
    "nbformat": 4,
-   "nbformat_minor": 1
+   "nbformat_minor": 0
   }

--- a/tests/test-keep-count.t
+++ b/tests/test-keep-count.t
@@ -1,0 +1,87 @@
+$ cat ${TESTDIR}/test_metadata.ipynb | ${NBSTRIPOUT_EXE:-nbstripout --keep-count}
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This notebook tests that cells with either `\"keep_output\": true` or `\"init_cell\": true` are not stripped."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {
+    "init_cell": true
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "2"
+      ]
+     },
+     "execution_count": 1,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "1+1 # This cell has `\"init_cell:\" true`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {
+    "keep_output": true
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "4"
+      ]
+     },
+     "execution_count": 2,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "2+2 # This cell has `\"keep_output:\" true`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "3+3"
+   ]
+  }
+ ],
+ "metadata": {
+  "celltoolbar": "Edit Metadata",
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.5.2"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 1
+}

--- a/tests/test-keep-count.t
+++ b/tests/test-keep-count.t
@@ -1,87 +1,87 @@
-$ cat ${TESTDIR}/test_metadata.ipynb | ${NBSTRIPOUT_EXE:-nbstripout --keep-count}
-{
- "cells": [
+  $ cat ${TESTDIR}/test_metadata.ipynb | ${NBSTRIPOUT_EXE:-nbstripout --keep-count}
   {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "This notebook tests that cells with either `\"keep_output\": true` or `\"init_cell\": true` are not stripped."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 1,
-   "metadata": {
-    "init_cell": true
-   },
-   "outputs": [
+   "cells": [
     {
-     "data": {
-      "text/plain": [
-       "2"
-      ]
-     },
+     "cell_type": "markdown",
+     "metadata": {},
+     "source": [
+      "This notebook tests that cells with either `\"keep_output\": true` or `\"init_cell\": true` are not stripped."
+     ]
+    },
+    {
+     "cell_type": "code",
      "execution_count": 1,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "1+1 # This cell has `\"init_cell:\" true`"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 2,
-   "metadata": {
-    "keep_output": true
-   },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "4"
-      ]
+     "metadata": {
+      "init_cell": true
      },
+     "outputs": [
+      {
+       "data": {
+        "text/plain": [
+         "2"
+        ]
+       },
+       "execution_count": 1,
+       "metadata": {},
+       "output_type": "execute_result"
+      }
+     ],
+     "source": [
+      "1+1 # This cell has `\"init_cell:\" true`"
+     ]
+    },
+    {
+     "cell_type": "code",
      "execution_count": 2,
+     "metadata": {
+      "keep_output": true
+     },
+     "outputs": [
+      {
+       "data": {
+        "text/plain": [
+         "4"
+        ]
+       },
+       "execution_count": 2,
+       "metadata": {},
+       "output_type": "execute_result"
+      }
+     ],
+     "source": [
+      "2+2 # This cell has `\"keep_output:\" true`"
+     ]
+    },
+    {
+     "cell_type": "code",
+     "execution_count": 3,
      "metadata": {},
-     "output_type": "execute_result"
+     "outputs": [],
+     "source": [
+      "3+3"
+     ]
     }
    ],
-   "source": [
-    "2+2 # This cell has `\"keep_output:\" true`"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 3,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "3+3"
-   ]
-  }
- ],
- "metadata": {
-  "celltoolbar": "Edit Metadata",
-  "kernelspec": {
-   "display_name": "Python 3",
-   "language": "python",
-   "name": "python3"
-  },
-  "language_info": {
-   "codemirror_mode": {
-    "name": "ipython",
-    "version": 3
+   "metadata": {
+    "celltoolbar": "Edit Metadata",
+    "kernelspec": {
+     "display_name": "Python 3",
+     "language": "python",
+     "name": "python3"
+    },
+    "language_info": {
+     "codemirror_mode": {
+      "name": "ipython",
+      "version": 3
+     },
+     "file_extension": ".py",
+     "mimetype": "text/x-python",
+     "name": "python",
+     "nbconvert_exporter": "python",
+     "pygments_lexer": "ipython3",
+     "version": "3.5.2"
+    }
    },
-   "file_extension": ".py",
-   "mimetype": "text/x-python",
-   "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.5.2"
+   "nbformat": 4,
+   "nbformat_minor": 1
   }
- },
- "nbformat": 4,
- "nbformat_minor": 1
-}

--- a/tests/test-keep-output-keep-count.t
+++ b/tests/test-keep-output-keep-count.t
@@ -76,23 +76,23 @@
    "metadata": {
     "celltoolbar": "Edit Metadata",
     "kernelspec": {
-     "display_name": "Python 3",
+     "display_name": "Python 2",
      "language": "python",
-     "name": "python3"
+     "name": "python2"
     },
     "language_info": {
      "codemirror_mode": {
       "name": "ipython",
-      "version": 3
+      "version": 2
      },
      "file_extension": ".py",
      "mimetype": "text/x-python",
      "name": "python",
      "nbconvert_exporter": "python",
-     "pygments_lexer": "ipython3",
-     "version": "3.5.2"
+     "pygments_lexer": "ipython2",
+     "version": "2.7.11"
     }
    },
    "nbformat": 4,
-   "nbformat_minor": 1
+   "nbformat_minor": 0
   }

--- a/tests/test-keep-output-keep-count.t
+++ b/tests/test-keep-output-keep-count.t
@@ -1,98 +1,98 @@
-$ cat ${TESTDIR}/test_metadata.ipynb | ${NBSTRIPOUT_EXE:-nbstripout --keep-output --keep-count}
-{
- "cells": [
+  $ cat ${TESTDIR}/test_metadata.ipynb | ${NBSTRIPOUT_EXE:-nbstripout --keep-output --keep-count}
   {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "This notebook tests that cells with either `\"keep_output\": true` or `\"init_cell\": true` are not stripped."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 1,
-   "metadata": {
-    "init_cell": true
-   },
-   "outputs": [
+   "cells": [
     {
-     "data": {
-      "text/plain": [
-       "2"
-      ]
-     },
+     "cell_type": "markdown",
+     "metadata": {},
+     "source": [
+      "This notebook tests that cells with either `\"keep_output\": true` or `\"init_cell\": true` are not stripped."
+     ]
+    },
+    {
+     "cell_type": "code",
      "execution_count": 1,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "1+1 # This cell has `\"init_cell:\" true`"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 2,
-   "metadata": {
-    "keep_output": true
-   },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "4"
-      ]
+     "metadata": {
+      "init_cell": true
      },
+     "outputs": [
+      {
+       "data": {
+        "text/plain": [
+         "2"
+        ]
+       },
+       "execution_count": 1,
+       "metadata": {},
+       "output_type": "execute_result"
+      }
+     ],
+     "source": [
+      "1+1 # This cell has `\"init_cell:\" true`"
+     ]
+    },
+    {
+     "cell_type": "code",
      "execution_count": 2,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "2+2 # This cell has `\"keep_output:\" true`"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 3,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "6"
-      ]
+     "metadata": {
+      "keep_output": true
      },
+     "outputs": [
+      {
+       "data": {
+        "text/plain": [
+         "4"
+        ]
+       },
+       "execution_count": 2,
+       "metadata": {},
+       "output_type": "execute_result"
+      }
+     ],
+     "source": [
+      "2+2 # This cell has `\"keep_output:\" true`"
+     ]
+    },
+    {
+     "cell_type": "code",
      "execution_count": 3,
      "metadata": {},
-     "output_type": "execute_result"
+     "outputs": [
+      {
+       "data": {
+        "text/plain": [
+         "6"
+        ]
+       },
+       "execution_count": 3,
+       "metadata": {},
+       "output_type": "execute_result"
+      }
+     ],
+     "source": [
+      "3+3"
+     ]
     }
    ],
-   "source": [
-    "3+3"
-   ]
-  }
- ],
- "metadata": {
-  "celltoolbar": "Edit Metadata",
-  "kernelspec": {
-   "display_name": "Python 3",
-   "language": "python",
-   "name": "python3"
-  },
-  "language_info": {
-   "codemirror_mode": {
-    "name": "ipython",
-    "version": 3
+   "metadata": {
+    "celltoolbar": "Edit Metadata",
+    "kernelspec": {
+     "display_name": "Python 3",
+     "language": "python",
+     "name": "python3"
+    },
+    "language_info": {
+     "codemirror_mode": {
+      "name": "ipython",
+      "version": 3
+     },
+     "file_extension": ".py",
+     "mimetype": "text/x-python",
+     "name": "python",
+     "nbconvert_exporter": "python",
+     "pygments_lexer": "ipython3",
+     "version": "3.5.2"
+    }
    },
-   "file_extension": ".py",
-   "mimetype": "text/x-python",
-   "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.5.2"
+   "nbformat": 4,
+   "nbformat_minor": 1
   }
- },
- "nbformat": 4,
- "nbformat_minor": 1
-}

--- a/tests/test-keep-output-keep-count.t
+++ b/tests/test-keep-output-keep-count.t
@@ -1,0 +1,98 @@
+$ cat ${TESTDIR}/test_metadata.ipynb | ${NBSTRIPOUT_EXE:-nbstripout --keep-output --keep-count}
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This notebook tests that cells with either `\"keep_output\": true` or `\"init_cell\": true` are not stripped."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {
+    "init_cell": true
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "2"
+      ]
+     },
+     "execution_count": 1,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "1+1 # This cell has `\"init_cell:\" true`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {
+    "keep_output": true
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "4"
+      ]
+     },
+     "execution_count": 2,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "2+2 # This cell has `\"keep_output:\" true`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "6"
+      ]
+     },
+     "execution_count": 3,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "3+3"
+   ]
+  }
+ ],
+ "metadata": {
+  "celltoolbar": "Edit Metadata",
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.5.2"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 1
+}

--- a/tests/test-keep-output.t
+++ b/tests/test-keep-output.t
@@ -1,98 +1,98 @@
-$ cat ${TESTDIR}/test_metadata.ipynb | ${NBSTRIPOUT_EXE:-nbstripout --keep-output}
-{
- "cells": [
+  $ cat ${TESTDIR}/test_metadata.ipynb | ${NBSTRIPOUT_EXE:-nbstripout --keep-output}
   {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "This notebook tests that cells with either `\"keep_output\": true` or `\"init_cell\": true` are not stripped."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
+   "cells": [
+    {
+     "cell_type": "markdown",
+     "metadata": {},
+     "source": [
+      "This notebook tests that cells with either `\"keep_output\": true` or `\"init_cell\": true` are not stripped."
+     ]
+    },
+    {
+     "cell_type": "code",
+     "execution_count": null,
+     "metadata": {
+      "init_cell": true
+     },
+     "outputs": [
+      {
+       "data": {
+        "text/plain": [
+         "2"
+        ]
+       },
+       "execution_count": null,
+       "metadata": {},
+       "output_type": "execute_result"
+      }
+     ],
+     "source": [
+      "1+1 # This cell has `\"init_cell:\" true`"
+     ]
+    },
+    {
+     "cell_type": "code",
+     "execution_count": null,
+     "metadata": {
+      "keep_output": true
+     },
+     "outputs": [
+      {
+       "data": {
+        "text/plain": [
+         "4"
+        ]
+       },
+       "execution_count": null,
+       "metadata": {},
+       "output_type": "execute_result"
+      }
+     ],
+     "source": [
+      "2+2 # This cell has `\"keep_output:\" true`"
+     ]
+    },
+    {
+     "cell_type": "code",
+     "execution_count": null,
+     "metadata": {},
+     "outputs": [
+      {
+       "data": {
+        "text/plain": [
+         "6"
+        ]
+       },
+       "execution_count": null,
+       "metadata": {},
+       "output_type": "execute_result"
+      }
+     ],
+     "source": [
+      "3+3"
+     ]
+    }
+   ],
    "metadata": {
-    "init_cell": true
+    "celltoolbar": "Edit Metadata",
+    "kernelspec": {
+     "display_name": "Python 2",
+     "language": "python",
+     "name": "python2"
+    },
+    "language_info": {
+     "codemirror_mode": {
+      "name": "ipython",
+      "version": 2
+     },
+     "file_extension": ".py",
+     "mimetype": "text/x-python",
+     "name": "python",
+     "nbconvert_exporter": "python",
+     "pygments_lexer": "ipython2",
+     "version": "2.7.11"
+    }
    },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "2"
-      ]
-     },
-     "execution_count": null,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "1+1 # This cell has `\"init_cell:\" true`"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "keep_output": true
-   },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "4"
-      ]
-     },
-     "execution_count": null,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "2+2 # This cell has `\"keep_output:\" true`"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "6"
-      ]
-     },
-     "execution_count": null,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "3+3"
-   ]
+   "nbformat": 4,
+   "nbformat_minor": 0
   }
- ],
- "metadata": {
-  "celltoolbar": "Edit Metadata",
-  "kernelspec": {
-   "display_name": "Python 2",
-   "language": "python",
-   "name": "python2"
-  },
-  "language_info": {
-   "codemirror_mode": {
-    "name": "ipython",
-    "version": 2
-   },
-   "file_extension": ".py",
-   "mimetype": "text/x-python",
-   "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython2",
-   "version": "2.7.11"
-  }
- },
- "nbformat": 4,
- "nbformat_minor": 0
-}

--- a/tests/test-keep-output.t
+++ b/tests/test-keep-output.t
@@ -1,0 +1,98 @@
+$ cat ${TESTDIR}/test_metadata.ipynb | ${NBSTRIPOUT_EXE:-nbstripout --keep-output}
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This notebook tests that cells with either `\"keep_output\": true` or `\"init_cell\": true` are not stripped."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "init_cell": true
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "2"
+      ]
+     },
+     "execution_count": null,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "1+1 # This cell has `\"init_cell:\" true`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "keep_output": true
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "4"
+      ]
+     },
+     "execution_count": null,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "2+2 # This cell has `\"keep_output:\" true`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "6"
+      ]
+     },
+     "execution_count": null,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "3+3"
+   ]
+  }
+ ],
+ "metadata": {
+  "celltoolbar": "Edit Metadata",
+  "kernelspec": {
+   "display_name": "Python 2",
+   "language": "python",
+   "name": "python2"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 2
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython2",
+   "version": "2.7.11"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 0
+}

--- a/tests/test-metadata.t
+++ b/tests/test-metadata.t
@@ -10,9 +10,8 @@
     },
     {
      "cell_type": "code",
-     "execution_count": 1,
+     "execution_count": null,
      "metadata": {
-      "collapsed": false,
       "init_cell": true
      },
      "outputs": [
@@ -22,7 +21,7 @@
          "2"
         ]
        },
-       "execution_count": 1,
+       "execution_count": null,
        "metadata": {},
        "output_type": "execute_result"
       }
@@ -33,9 +32,8 @@
     },
     {
      "cell_type": "code",
-     "execution_count": 2,
+     "execution_count": null,
      "metadata": {
-      "collapsed": false,
       "keep_output": true
      },
      "outputs": [
@@ -45,7 +43,7 @@
          "4"
         ]
        },
-       "execution_count": 2,
+       "execution_count": null,
        "metadata": {},
        "output_type": "execute_result"
       }


### PR DESCRIPTION
I developed this for my own use case where I wanted to version control the source and its outputs, but not the execution count and other miscellaneous metadata. These two options give fine grained control of nbstripout's behaviour.