### PR TITLE
Change shell pipeline example

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -58,7 +58,7 @@ Force processing of non ``.ipynb`` files: ::
 
 Use as part of a shell pipeline: ::
 
-    FILE.ipynb | nbstripout > OUT.ipynb
+    cat FILE.ipynb | nbstripout > OUT.ipynb
 
 Set up the git filter and attributes as described in the manual installation
 instructions below: ::


### PR DESCRIPTION
The current shell pipeline example in readme.rst doesn't use `cat`
while the example in the nbstripout.py
[docstring](https://github.com/kynan/nbstripout/blob/master/nbstripout.py#L29) does.