### PR TITLE
Fix unexpected behaviors

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,3 +11,4 @@ before_install:
 install:
   - python setup.py install
 script: python setup.py test
+dist: precise

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,9 +6,10 @@ python:
   - "3.5"
   - "3.6"
 before_install:
-  - pip install --upgrade pytest
-  - pip install nbformat
+  - travis_retry pip install --upgrade pytest
+  - travis_retry pip install nbformat
 install:
-  - python setup.py install
-script: python setup.py test
+  - travis_retry python setup.py install
+script:
+  - travis_retry python setup.py test
 dist: precise

--- a/nbstripout.py
+++ b/nbstripout.py
@@ -342,6 +342,7 @@ def main():
             nb = strip_output(nb, args.keep_output, args.keep_count)
             if args.textconv:
                 write(nb, output_stream)
+                output_stream.flush()
             else:
                 with io.open(filename, 'w', encoding='utf8') as f:
                     write(nb, f)

--- a/setup.py
+++ b/setup.py
@@ -12,6 +12,7 @@ setup_requires = [
 ]
 
 tests_require = [
+    'setuptools >= 30',
     'pytest',
     'pytest-flake8',
     'pytest-cram == 0.1.1',

--- a/setup.py
+++ b/setup.py
@@ -8,11 +8,11 @@ install_requires = [
 ]
 
 setup_requires = [
-    'pytest-runner'
+    'pytest-runner',
+    'setuptools >= 30'
 ]
 
 tests_require = [
-    'setuptools >= 30',
     'pytest',
     'pytest-flake8',
     'pytest-cram == 0.1.1',

--- a/setup.py
+++ b/setup.py
@@ -3,6 +3,10 @@ from setuptools import setup
 with open('README.rst') as f:
     long_description = f.read()
 
+install_requires = [
+    'nbformat'
+]
+
 setup_requires = [
     'pytest-runner'
 ]
@@ -34,6 +38,7 @@ setup(name='nbstripout',
           ],
       },
 
+      install_requires=install_requires,
       setup_requires=setup_requires,
       tests_require=tests_require,
 


### PR DESCRIPTION
I've been using `nbstripout` for a while. For the purpose of this discussion, let's say I have it installed on two machines:

- Server: Ubuntu 14.04, Python 2.7.6
- Desktop: Ubuntu 16.04, Python 3.5.2

I'm on `nbstripout` 0.3.1 and `git` is throwing a lot of weird diffs when I push/pull across the two machines, so I started poking around.

On the desktop, I found that I get empty output from `nbstripout -t`. I investigated and found that the output stream was not flushed properly, so I fixed that. (9c24cbd)

Now, I get output from `nbstripout -t`, but the output between two machines are different. Took me a while to found that `pip3` says I don't even have `nbformat`. I installed `nbformat` and things are working properly now. (852bf85)

So here I am, submitting a pull request.