### PR TITLE
Set newline to LF when processing .ipynb files

### DIFF
--- a/nbstripout.py
+++ b/nbstripout.py
@@ -344,7 +344,7 @@ def main():
                 write(nb, output_stream)
                 output_stream.flush()
             else:
-                with io.open(filename, 'w', encoding='utf8') as f:
+                with io.open(filename, 'w', encoding='utf8', newline='\n') as f:
                     write(nb, f)
         except NotJSONError:
             print("'{}' is not a valid notebook".format(filename), file=sys.stderr)


### PR DESCRIPTION
It seems to me that jupyter notebook will save the files using LF even on a windows machine. This created some problems using nbstripout with git on windows as it converts to CRLF. 