### PR TITLE
Fix git diff tests by using --no-index. Fix #74

### DIFF
--- a/tests/test-git.t
+++ b/tests/test-git.t
@@ -6,9 +6,8 @@
   [1]
   $ ${NBSTRIPOUT_EXE:-nbstripout} --install
   $ ${NBSTRIPOUT_EXE:-nbstripout} --is-installed
-  $ git diff --no-ext-diff --unified=0 --exit-code -a --no-prefix ${TESTDIR}/test_diff.ipynb ${TESTDIR}/test_diff_output.ipynb 
-  [1]
-  $ git diff ${TESTDIR}/test_diff.ipynb ${TESTDIR}/test_diff_different.ipynb 
+  $ git diff --no-index --no-ext-diff --unified=0 --exit-code -a --no-prefix ${TESTDIR}/test_diff.ipynb ${TESTDIR}/test_diff_output.ipynb
+  $ git diff --no-index ${TESTDIR}/test_diff.ipynb ${TESTDIR}/test_diff_different.ipynb
   (diff --git.*) (re)
   (index .*) (re)
   (--- .*test_diff.ipynb) (re)


### PR DESCRIPTION
With --no-index, git diff compares two files. Otherwise, it would compare the working directory states of those files to their states in the index.

This should fix #74.

Anyway, please check that this makes sense. I'm not 100% certain I did the right thing.