### PR TITLE
Add tests to sdist (MANIFEST.in). Fix #73

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,5 @@
 # Include the license file
 include LICENSE.txt
+
+# Include tests
+include tests/*


### PR DESCRIPTION
This allows people to run tests when downloading the source tarball from PyPI.