### PR TITLE
make sure sys.stdin is not None (2), fixes #80

### DIFF
--- a/nbstripout.py
+++ b/nbstripout.py
@@ -91,16 +91,19 @@ from argparse import ArgumentParser, RawDescriptionHelpFormatter
 import io
 import sys
 
+input_stream = None
 if sys.version_info < (3, 0):
     import codecs
     # Use UTF8 reader/writer for stdin/stdout
     # http://stackoverflow.com/a/1169209
-    input_stream = codecs.getreader('utf8')(sys.stdin)
+    if sys.stdin is not None:
+        input_stream = codecs.getreader('utf8')(sys.stdin)
     output_stream = codecs.getwriter('utf8')(sys.stdout)
 else:
     # Wrap input/output stream in UTF-8 encoded text wrapper
     # https://stackoverflow.com/a/16549381
-    input_stream = io.TextIOWrapper(sys.stdin.buffer, encoding='utf-8')
+    if sys.stdin is not None:
+        input_stream = io.TextIOWrapper(sys.stdin.buffer, encoding='utf-8')
     output_stream = io.TextIOWrapper(sys.stdout.buffer, encoding='utf-8')
 
 __version__ = '0.3.2'
@@ -354,7 +357,7 @@ def main():
             print("Could not strip '{}'".format(filename), file=sys.stderr)
             raise
 
-    if not args.files:
+    if not args.files and input_stream is not None:
         try:
             nb = strip_output(read(input_stream, as_version=NO_CONVERT),
                               args.keep_output, args.keep_count)

--- a/nbstripout.py
+++ b/nbstripout.py
@@ -96,13 +96,13 @@ if sys.version_info < (3, 0):
     import codecs
     # Use UTF8 reader/writer for stdin/stdout
     # http://stackoverflow.com/a/1169209
-    if sys.stdin is not None:
+    if sys.stdin:
         input_stream = codecs.getreader('utf8')(sys.stdin)
     output_stream = codecs.getwriter('utf8')(sys.stdout)
 else:
     # Wrap input/output stream in UTF-8 encoded text wrapper
     # https://stackoverflow.com/a/16549381
-    if sys.stdin is not None:
+    if sys.stdin:
         input_stream = io.TextIOWrapper(sys.stdin.buffer, encoding='utf-8')
     output_stream = io.TextIOWrapper(sys.stdout.buffer, encoding='utf-8')
 
@@ -357,7 +357,7 @@ def main():
             print("Could not strip '{}'".format(filename), file=sys.stderr)
             raise
 
-    if not args.files and input_stream is not None:
+    if not args.files and input_stream:
         try:
             nb = strip_output(read(input_stream, as_version=NO_CONVERT),
                               args.keep_output, args.keep_count)


### PR DESCRIPTION
sys.stdin is None on Windows sometimes, make sure it is well defined, please see issue #80 

better fix, replaces pull request #81