### PR TITLE
Fix quotes in git filter-branch commands

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -109,7 +109,7 @@ uses ``--index-filter`` and operates on all ipynb-files in the repo: ::
 
     git filter-branch -f --index-filter '
         git checkout -- :*.ipynb
-        find . -name '*.ipynb' -exec nbstripout {} +
+        find . -name "*.ipynb" -exec nbstripout "{}" +
         git add . --ignore-removal
     '
 
@@ -120,7 +120,7 @@ stderr to ``/dev/null``.
 
 This is a potentially slower but simpler invocation using ``--tree-filter``: ::
 
-    git filter-branch -f --tree-filter 'find . -name "*.ipynb" -exec nbstripout {} +'
+    git filter-branch -f --tree-filter 'find . -name "*.ipynb" -exec nbstripout "{}" +'
 
 Keeping some output
 +++++++++++++++++++


### PR DESCRIPTION
Two minor suggestions for the README, based on some filter-branch experience today:

1. The `{}` should be quoted, in case the file names have spaces (😱). This is the approach taken in https://stackoverflow.com/a/27915683/2053820.

2. AFAICT, single quotes within a single-quoted string seem to be removed, which I don't think is the intention here:

```
$ echo '
> 'hi'
> '

hi
```
vs
```
$ echo '
> "hi"
> '

"hi"
```

```
$ bash --version
GNU bash, version 3.2.57(1)-release (x86_64-apple-darwin16)
Copyright (C) 2007 Free Software Foundation, Inc.
```