### PR TITLE
Add support for "pre-commit" hooks manager

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,0 +1,9 @@
+- id: nbstripout
+  name: nbstripout
+  description: |
+    Make shure to clean jupyter notebooks before commit.
+    https://pypi.python.org/pypi/nbstripout
+  entry: nbstripout
+  language: python
+  files: '.*\.ipynb$'
+  stages: [commit, push, manual]

--- a/nbstripout.py
+++ b/nbstripout.py
@@ -106,7 +106,7 @@ else:
         input_stream = io.TextIOWrapper(sys.stdin.buffer, encoding='utf-8')
     output_stream = io.TextIOWrapper(sys.stdout.buffer, encoding='utf-8')
 
-__version__ = '0.3.3'
+__version__ = '0.3.4'
 
 try:
     # Jupyter >= 4

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.3.3
+current_version = 0.3.4
 commit = True
 tag = True
 tag_name = {new_version}

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ tests_require = [
 ]
 
 setup(name='nbstripout',
-      version='0.3.3',
+      version='0.3.4',
 
       author='Min RK',
       author_email='benjaminrk@gmail.com',


### PR DESCRIPTION
So that users of [pre-commit](https://pre-commit.com/) could add something like
```yaml
- repo: https://github.com/kynan/nbstripout
  rev: master
  hooks:
    - id: nbstripout
```
to their `.pre-commit-config.yaml` file
and have their notebooks cleaned before commit.

I hope this might be useful.