### PR TITLE
Make nbstripout compatible with pre-commit

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,0 +1,6 @@
+-   id: nbstripout
+    name: nbstripout
+    description: "Apply nbstripout"
+    entry: nbstripout
+    language: python
+    files: ''


### PR DESCRIPTION
This config file makes the nbstripout package compatible with the [pre-commit](https://pre-commit.com/) commit hooks package.  Using my fork you just need to add:
```
- repo: https://github.com/rdturnermtl/nbstripout
  sha: d5ebb11ad97dfc3306a4c351adabbd6c2f4dbfdd
  hooks:
    - id: nbstripout
```
to a `.pre-commit-config.yaml` in a repo to make it use nbstripout as a hook.

After merging into this repo, the new yaml config will be:
```
- repo: https://github.com/kynan/nbstripout
  sha: 0.3.6
  hooks:
    - id: nbstripout
```