### PR TITLE
Fix #111: Properly quote script paths for Git

### DIFF
--- a/nbstripout/_nbstripout.py
+++ b/nbstripout/_nbstripout.py
@@ -135,8 +135,7 @@ def install(git_config, attrfile=None):
     except CalledProcessError:
         print('Installation failed: not a git repository!', file=sys.stderr)
         sys.exit(1)
-    dir = path.abspath(path.dirname(__file__))
-    filepath = '"{}" "{}"'.format(sys.executable, dir).replace('\\', '/')
+    filepath = "'{}' -m nbstripout".format(sys.executable.replace('\\', '/'))
     check_call(git_config + ['filter.nbstripout.clean', filepath])
     check_call(git_config + ['filter.nbstripout.smudge', 'cat'])
     check_call(git_config + ['diff.ipynb.textconv', filepath + ' -t'])


### PR DESCRIPTION
Git quotes `"` to `\"`, which is invalid. But it seems to not quote `'` to `\'`, so switch to that.

Also fix the name of 'nbstripout', since it's never going to change.