### PR TITLE
Support specifying keep_output as a cell tag

### DIFF
--- a/nbstripout/__init__.py
+++ b/nbstripout/__init__.py
@@ -1,5 +1,5 @@
 from ._nbstripout import install, uninstall, status, main, __doc__ as docstring
-from ._utils import pop_recursive, strip_output
+from ._utils import pop_recursive, strip_output, MetadataError
 __all__ = ["install", "uninstall", "status", "main",
-           "pop_recursive", "strip_output"]
+           "pop_recursive", "strip_output", "MetadataError"]
 __doc__ = docstring

--- a/nbstripout/_utils.py
+++ b/nbstripout/_utils.py
@@ -1,9 +1,9 @@
 import sys
 
-__all__ = ["pop_recursive", "strip_output", "NBStripoutError"]
+__all__ = ["pop_recursive", "strip_output", "MetadataError"]
 
 
-class NBStripoutError(Exception):
+class MetadataError(Exception):
     pass
 
 
@@ -48,21 +48,20 @@ def determine_keep_output(cell, default):
         return bool(cell.metadata.init_cell)
 
     has_keep_output_metadata = 'keep_output' in cell.metadata
-    keep_output_metadata_bool = bool(cell.metadata.get('keep_output', False))
+    keep_output_metadata = bool(cell.metadata.get('keep_output', False))
 
     has_keep_output_tag = 'keep_output' in cell.metadata.get('tags', [])
 
     # keep_output between metadata and tags should not contradict each other
-    if has_keep_output_metadata and has_keep_output_tag and not keep_output_metadata_bool:
-        raise NBStripoutError(
+    if has_keep_output_metadata and has_keep_output_tag and not keep_output_metadata:
+        raise MetadataError(
             "cell metadata contradicts tags: "
             "\"keep_output\": false, but keep_output in tags"
         )
 
     if has_keep_output_metadata or has_keep_output_tag:
-        return keep_output_metadata_bool or has_keep_output_tag
-    else:
-        return default
+        return keep_output_metadata or has_keep_output_tag
+    return default
 
 
 def strip_output(nb, keep_output, keep_count, extra_keys=''):

--- a/tests/test_keep_output_tags.ipynb
+++ b/tests/test_keep_output_tags.ipynb
@@ -1,0 +1,106 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This notebook tests that output is stripped unless the cell has a `keep_output` tag in its metadata"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2020-03-15T03:18:30.324432Z",
+     "start_time": "2020-03-15T03:18:30.313427Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "This cell should have no output, because it does not have keep_output in its metadata (top level) or its tags\n"
+     ]
+    }
+   ],
+   "source": [
+    "# no_output\n",
+    "print('''This cell should have no output, because it does not have keep_output in its metadata (top level) or its tags''')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2020-03-15T03:18:30.381986Z",
+     "start_time": "2020-03-15T03:18:30.329424Z"
+    },
+    "tags": [
+     "keep_output"
+    ]
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "This cell has keep_output in its tags metadata\n"
+     ]
+    }
+   ],
+   "source": [
+    "# output\n",
+    "print('''This cell has keep_output in its tags metadata''')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2020-03-15T03:18:30.393917Z",
+     "start_time": "2020-03-15T03:18:30.386910Z"
+    },
+    "keep_output": true
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "This cell has \"keep_output\": true in it's metadata but not in its tags\n"
+     ]
+    }
+   ],
+   "source": [
+    "# output\n",
+    "print('''This cell has \"keep_output\": true in it's metadata but not in its tags''')"
+   ]
+  }
+ ],
+ "metadata": {
+  "celltoolbar": "Edit Metadata",
+  "kernelspec": {
+   "display_name": "local",
+   "language": "python",
+   "name": "local"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.4"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/tests/test_keep_output_tags.py
+++ b/tests/test_keep_output_tags.py
@@ -1,20 +1,25 @@
 from copy import deepcopy
+import os
 import re
 
 import nbformat
 import pytest
 
-from nbstripout._utils import strip_output, NBStripoutError
+from nbstripout import strip_output, MetadataError
+
+directory = os.path.dirname(__file__)
 
 
 @pytest.fixture
 def orig_nb():
-    return nbformat.read('test_keep_output_tags.ipynb', nbformat.NO_CONVERT)
+    fname = 'test_keep_output_tags.ipynb'
+    return nbformat.read(os.path.join(directory, fname), nbformat.NO_CONVERT)
 
 
 @pytest.fixture
 def nb_with_exception():
-    return nbformat.read('test_keep_output_tags_exception.ipynb', nbformat.NO_CONVERT)
+    fname = 'test_keep_output_tags_exception.ipynb'
+    return nbformat.read(os.path.join(directory, fname), nbformat.NO_CONVERT)
 
 
 def test_cells(orig_nb):
@@ -35,5 +40,5 @@ def test_cells(orig_nb):
 
 
 def test_exception(nb_with_exception):
-    with pytest.raises(NBStripoutError):
+    with pytest.raises(MetadataError):
         strip_output(nb_with_exception, None, None)

--- a/tests/test_keep_output_tags.py
+++ b/tests/test_keep_output_tags.py
@@ -1,0 +1,39 @@
+from copy import deepcopy
+import re
+
+import nbformat
+import pytest
+
+from nbstripout._utils import strip_output, NBStripoutError
+
+
+@pytest.fixture
+def orig_nb():
+    return nbformat.read('test_keep_output_tags.ipynb', nbformat.NO_CONVERT)
+
+
+@pytest.fixture
+def nb_with_exception():
+    return nbformat.read('test_keep_output_tags_exception.ipynb', nbformat.NO_CONVERT)
+
+
+def test_cells(orig_nb):
+    nb_stripped = deepcopy(orig_nb)
+    nb_stripped = strip_output(nb_stripped, None, None)
+    for i, cell in enumerate(nb_stripped.cells):
+        if cell.cell_type == 'code' and cell.source:
+            match = re.match(r"\s*#\s*(output|no_output)", cell.source)
+            if match:
+                # original cell should have had output.
+                # If not, there's a problem with the test fixture
+                assert orig_nb.cells[i].outputs
+
+                if match.group(1) == 'output':
+                    assert len(cell.outputs) > 0
+                else:
+                    assert len(cell.outputs) == 0
+
+
+def test_exception(nb_with_exception):
+    with pytest.raises(NBStripoutError):
+        strip_output(nb_with_exception, None, None)

--- a/tests/test_keep_output_tags_exception.ipynb
+++ b/tests/test_keep_output_tags_exception.ipynb
@@ -1,0 +1,60 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This notebook tests that output is stripped unless the cell has a `keep_output` tag in its metadata"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2020-03-15T03:18:30.406033Z",
+     "start_time": "2020-03-15T03:18:30.398910Z"
+    },
+    "keep_output": false,
+    "tags": [
+     "keep_output"
+    ]
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "This cell should raise an exception, because the metadata and tags conflict in terms of keep_output\n"
+     ]
+    }
+   ],
+   "source": [
+    "# exception\n",
+    "print('''This cell should raise an exception, because the metadata and tags conflict in terms of keep_output''')"
+   ]
+  }
+ ],
+ "metadata": {
+  "celltoolbar": "Edit Metadata",
+  "kernelspec": {
+   "display_name": "local",
+   "language": "python",
+   "name": "local"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.4"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}


### PR DESCRIPTION
I suggested in #117 that it would be nice to be able to mark a cell for keeping output via the cell tags. Cell tags are easier to see and modify (if you set View > cell toolbar > tags). 

I have implemented this functionality in this pull request. I include tests as well, though I do so with pure `pytest` instead of `cram`, because `cram` does not work on Windows and that's what I have at the moment. In the test fixtures (notebooks), 

`"keep_output": true` as a top-level cell key still works, but I raise an exception if it has both `"keep_output": false` _**and**_ a `keep_output` tag, as that would be an explicit contradiction that the user should resolve. 

**Testing note:** In my test fixtures I denote code cells as supposed to have (or not have) output using a comment line at the beginning of the code cell source. I specify the case where an exception should be raised also by a comment at the beginning of the corresponding code cell source. 