### PR TITLE
add newline param to open and TextIOWrapper method

### DIFF
--- a/nbstripout/_nbstripout.py
+++ b/nbstripout/_nbstripout.py
@@ -159,7 +159,7 @@ def install(git_config, attrfile=None):
         if filt_exists and diff_exists:
             return
 
-    with open(attrfile, 'a') as f:
+    with open(attrfile, 'a', newline='') as f:
         # If the file already exists, ensure it ends with a new line
         if f.tell():
             f.write('\n')
@@ -303,7 +303,7 @@ def main():
         # https://stackoverflow.com/a/16549381
         if sys.stdin:
             input_stream = io.TextIOWrapper(sys.stdin.buffer, encoding='utf-8')
-        output_stream = io.TextIOWrapper(sys.stdout.buffer, encoding='utf-8')
+        output_stream = io.TextIOWrapper(sys.stdout.buffer, encoding='utf-8', newline='')
 
     for filename in args.files:
         if not (args.force or filename.endswith('.ipynb')):
@@ -320,7 +320,7 @@ def main():
                 write(nb, output_stream)
                 output_stream.flush()
             else:
-                with io.open(filename, 'w', encoding='utf8') as f:
+                with io.open(filename, 'w', encoding='utf8', newline='') as f:
                     write(nb, f)
         except NotJSONError:
             print("'{}' is not a valid notebook".format(filename), file=sys.stderr)


### PR DESCRIPTION
# Purpose
To solve the issue #110.
I faced the same problem on my Windows environment.
nbstripout converts my ipynb file newline from LF to CRLF when I committing.

# Bug Cause
About the newline parameter of  ```open``` method and ```TextIOWrapper``` method
>When writing output to the stream, if newline is None, any '\n' characters written are translated to the system default line separator, os.linesep.

https://docs.python.org/3/library/io.html#io.TextIOWrapper
https://docs.python.org/3/library/functions.html#open-newline-parameter

os.linesep is
>The string used to separate (or, rather, terminate) lines on the current platform. This may be a single character, such as '\n' for POSIX, or multiple characters, for example, '\r\n' for Windows.

https://docs.python.org/3/library/os.html#os.linesep

# Bug Fix
Add ```newline=''``` parameter to ```open``` method and ```TextIOWrapper``` method
>  If newline is '' or '\n', no translation takes place.

https://docs.python.org/3/library/io.html#io.TextIOWrapper
https://docs.python.org/3/library/functions.html#open-newline-parameter


---
This is my first pull request.  
So I don't know if this is right way of pull request.
If there is any problem, please tell me.