### PR TITLE
fix attempting to install on python2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -41,6 +41,7 @@ setup(name='nbstripout',
       install_requires=install_requires,
       setup_requires=setup_requires,
       tests_require=tests_require,
+      python_requires='>=3.4',
 
       classifiers=[
           "Development Status :: 4 - Beta",


### PR DESCRIPTION
The `nbstripout==0.3.8` package was not built & released correctly, which means that `pip install -U nbstripout` will incorrectly install an incompatible version on `python2` (e.g. https://github.com/SyneRBI/SyneRBI_VM/issues/169)

This PR fixes this issue in future.