### PR TITLE
DOC no need to specify files in pre-commit example

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -342,7 +342,6 @@ Once you have `pre-commit`_ installed, add the follwong to the
       rev: master
       hooks:
         - id: nbstripout
-          files: ".ipynb"
 
 Then run ``pre-commit install`` to activate the hook.
 


### PR DESCRIPTION
There is already
```
types: [jupyter]
```
in `.pre-commit-hooks.yaml`