### PR TITLE
Support only stripping outputs larger than a given size

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -230,6 +230,10 @@ Do not strip the execution count/prompt number ::
 
     nbstripout --keep-count
 
+Do not strip outputs that are smaller that a given max size (useful for removing large outputs like images) ::
+
+    nbstripout --max-size 1k
+
 Do not strip the output ::
 
     nbstripout --keep-output

--- a/nbstripout/_nbstripout.py
+++ b/nbstripout/_nbstripout.py
@@ -193,6 +193,20 @@ def _get_attrfile(git_config, install_location=INSTALL_LOCATION_LOCAL, attrfile=
     return attrfile
 
 
+def _parse_size(num_str):
+    num_str = num_str.upper()
+    if num_str[-1].isdigit():
+        return int(num_str)
+    elif num_str[-1] == 'K':
+        return int(num_str[:-1]) * (10**3)
+    elif num_str[-1] == 'M':
+        return int(num_str[:-1]) * (10**6)
+    elif num_str[-1] == 'G':
+        return int(num_str[:-1]) * (10**9)
+    else:
+        raise ValueError("Unknown size identifier %s" % num_str[-1])
+
+
 def install(git_config, install_location=INSTALL_LOCATION_LOCAL, attrfile=None):
     """Install the git filter and set the git attributes."""
     try:
@@ -363,6 +377,8 @@ def main():
                           help='Use system git config (default is local config)')
     parser.add_argument('--force', '-f', action='store_true',
                         help='Strip output also from files with non ipynb extension')
+    parser.add_argument('--max-size', metavar='SIZE',
+                        help='Keep outputs smaller than SIZE', default='0')
 
     parser.add_argument('--textconv', '-t', action='store_true',
                         help='Prints stripped files to STDOUT')
@@ -427,7 +443,7 @@ def main():
                     warnings.simplefilter("ignore", category=UserWarning)
                     nb = read(f, as_version=NO_CONVERT)
 
-            nb = strip_output(nb, args.keep_output, args.keep_count, extra_keys, args.strip_empty_cells)
+            nb = strip_output(nb, args.keep_output, args.keep_count, extra_keys, args.strip_empty_cells, _parse_size(args.max_size))
 
             if args.dry_run:
                 output_stream.write('Dry run: would have stripped {}\n'.format(filename))
@@ -462,7 +478,7 @@ def main():
                 warnings.simplefilter("ignore", category=UserWarning)
                 nb = read(input_stream, as_version=NO_CONVERT)
 
-            nb = strip_output(nb, args.keep_output, args.keep_count, extra_keys, args.strip_empty_cells)
+            nb = strip_output(nb, args.keep_output, args.keep_count, extra_keys, args.strip_empty_cells, _parse_size(args.max_size))
 
             if args.dry_run:
                 output_stream.write('Dry run: would have stripped input from '

--- a/tests/test-max-size.t
+++ b/tests/test-max-size.t
@@ -1,0 +1,91 @@
+  $ cat ${TESTDIR}/test_max_size.ipynb | ${NBSTRIPOUT_EXE:-nbstripout} --max-size 50
+  {
+   "cells": [
+    {
+     "cell_type": "markdown",
+     "id": "336ba586",
+     "metadata": {},
+     "source": [
+      "This notebook tests that outputs can be cleared based on size"
+     ]
+    },
+    {
+     "cell_type": "code",
+     "execution_count": null,
+     "id": "a014078d",
+     "metadata": {},
+     "outputs": [
+      {
+       "name": "stdout",
+       "output_type": "stream",
+       "text": [
+        "aaaaaaaaaa\n"
+       ]
+      }
+     ],
+     "source": [
+      "print(\"a\"*10)"
+     ]
+    },
+    {
+     "cell_type": "code",
+     "execution_count": null,
+     "id": "89ff455b",
+     "metadata": {},
+     "outputs": [],
+     "source": [
+      "print(\"a\"*100)"
+     ]
+    }
+   ],
+   "metadata": {
+    "kernelspec": {
+     "display_name": "Python 3",
+     "language": "python",
+     "name": "python3"
+    },
+    "language_info": {
+     "codemirror_mode": {
+      "name": "ipython",
+      "version": 3
+     },
+     "file_extension": ".py",
+     "mimetype": "text/x-python",
+     "name": "python",
+     "nbconvert_exporter": "python",
+     "pygments_lexer": "ipython3",
+     "version": "3.9.4"
+    },
+    "varInspector": {
+     "cols": {
+      "lenName": 16,
+      "lenType": 16,
+      "lenVar": 40
+     },
+     "kernels_config": {
+      "python": {
+       "delete_cmd_postfix": "",
+       "delete_cmd_prefix": "del ",
+       "library": "var_list.py",
+       "varRefreshCmd": "print(var_dic_list())"
+      },
+      "r": {
+       "delete_cmd_postfix": ") ",
+       "delete_cmd_prefix": "rm(",
+       "library": "var_list.r",
+       "varRefreshCmd": "cat(var_dic_list()) "
+      }
+     },
+     "types_to_exclude": [
+      "module",
+      "function",
+      "builtin_function_or_method",
+      "instance",
+      "_Feature"
+     ],
+     "window_display": false
+    }
+   },
+   "nbformat": 4,
+   "nbformat_minor": 5
+  }

--- a/tests/test_max_size.ipynb
+++ b/tests/test_max_size.ipynb
@@ -1,0 +1,108 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "336ba586",
+   "metadata": {},
+   "source": [
+    "This notebook tests that outputs can be cleared based on size"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "a014078d",
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2021-05-02T02:39:41.848031Z",
+     "start_time": "2021-05-02T02:39:41.842433Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "aaaaaaaaaa\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(\"a\"*10)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "89ff455b",
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2021-05-02T02:39:55.772449Z",
+     "start_time": "2021-05-02T02:39:55.766400Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(\"a\"*100)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.4"
+  },
+  "varInspector": {
+   "cols": {
+    "lenName": 16,
+    "lenType": 16,
+    "lenVar": 40
+   },
+   "kernels_config": {
+    "python": {
+     "delete_cmd_postfix": "",
+     "delete_cmd_prefix": "del ",
+     "library": "var_list.py",
+     "varRefreshCmd": "print(var_dic_list())"
+    },
+    "r": {
+     "delete_cmd_postfix": ") ",
+     "delete_cmd_prefix": "rm(",
+     "library": "var_list.r",
+     "varRefreshCmd": "cat(var_dic_list()) "
+    }
+   },
+   "types_to_exclude": [
+    "module",
+    "function",
+    "builtin_function_or_method",
+    "instance",
+    "_Feature"
+   ],
+   "window_display": false
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
I need to be able to strip embedded images and videos from a notebook while leaving the smaller text output (similar to #58). This PR adds a `--max-size` option which removes output larger than `max-size` bytes.
```sh
$ nbstripout --max-size 5K test1.ipynb
$ nbstripout --max-size 100 test2.ipynb
$ nbstripout --max-size 1M test3.ipynb
```
This easily delineates larger binary outputs from smaller textual ones.

I did not want to just filter on keys (an alternative) because a matplotlib animation video may be embedded in a `text/html` key, but I don't want to remove every `text/html` key. I'm also not sure if embedded images are always `image/png` in all kernels and plotting backends.

I've run some ad-hoc benchmarks and computing the size of the outputs in negligible to the overall run time when enabled (~2%-4%). 

Thanks!