### PR TITLE
fix bugs

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -248,8 +248,8 @@ Additional metadata to be stripped can be configured via either
 
         git config --global filter.nbstripout.extrakeys '
           metadata.celltoolbar
-          metadata.kernel_spec.display_name
-          metadata.kernel_spec.name
+          metadata.kernelspec.display_name
+          metadata.kernelspec.name
           metadata.language_info.codemirror_mode.version
           metadata.language_info.pygments_lexer
           metadata.language_info.version

--- a/nbstripout/_nbstripout.py
+++ b/nbstripout/_nbstripout.py
@@ -308,7 +308,7 @@ def main():
         sys.exit(0)
 
     try:
-        extra_keys = check_output(git_config + ['filter.nbstripout.extrakeys']).strip()
+        extra_keys = check_output(git_config + ['filter.nbstripout.extrakeys']).strip().decode()
         if args.extra_keys:
             extra_keys = ' '.join((extra_keys, args.extra_keys))
     except (CalledProcessError, FileNotFoundError):


### PR DESCRIPTION
### READMe.rst:
No "kernel_spec", only "kernelspec".

### _nbstripout.py :
The `extra_keys` is a byte string, but `args.extra_keys` is a string.
Then `' '.join((extra_keys, args.extra_keys))` got an error.

