### PR TITLE
Adding support for Collapsable headings

### DIFF
--- a/nbstripout/_utils.py
+++ b/nbstripout/_utils.py
@@ -126,7 +126,7 @@ def strip_output(nb, keep_output, keep_count, extra_keys=''):
             for output_style in ['collapsed', 'scrolled']:
                 if output_style in cell.metadata:
                     cell.metadata[output_style] = False
-            for field in ['ExecuteTime', 'collapsed', 'execution', 'scrolled']:
+            for field in ['ExecuteTime', 'collapsed', 'execution', 'scrolled', 'heading_collapsed', 'hidden']:
                 cell.metadata.pop(field, None)
         for (extra, fields) in keys['cell'].items():
             if extra in cell:


### PR DESCRIPTION
The current version of `nbstripout` does not support metadata changes if you use popular adds on: collapsable heading from [nbextensions](https://jupyter-contrib-nbextensions.readthedocs.io/en/latest/nbextensions/collapsible_headings/readme.html). 

## Current behaviour
When using collapsable heading extension when a section is closed or open information is saved in Jupyter Notebook. 

## Desired behaviour
We want to limit all the changes to notebook to useful changes, so information, whether the user is using the extension, is irrelevant. 

## Fix
As this extension is essentially adding two new fields to the metadata field (either "hidden":True or none and "heading_collapsed:True" or again None) it is only needed to add this fields to ingore line. 

**Sidenote:** Current version from master of repository is not working so for my own purposes I removed last 5 commits to revert to Pypi version. 

This PR is adding a new commit on top of master. 