### PR TITLE
Strip metadata with periods in key name

### DIFF
--- a/nbstripout/_utils.py
+++ b/nbstripout/_utils.py
@@ -16,6 +16,8 @@ def pop_recursive(d, key, default=None):
     >>> d
     {'a': {'b': 1}}
     """
+    if key in d:
+        return d.pop(key)
     nested = key.split('.')
     current = d
     for k in nested[:-1]:

--- a/tests/test-metadata-period.t
+++ b/tests/test-metadata-period.t
@@ -1,0 +1,24 @@
+  $ cat ${TESTDIR}/test_metadata_period.ipynb | ${NBSTRIPOUT_EXE:-nbstripout} --extra-keys "cell.metadata.application/vnd.databricks.v1+cell metadata.application/vnd.databricks.v1+notebook"
+  {
+   "cells": [
+    {
+     "cell_type": "markdown",
+     "metadata": {},
+     "source": [
+      "This notebook tests that metadata keys with periods can be stripped."
+     ]
+    },
+    {
+     "cell_type": "code",
+     "execution_count": null,
+     "metadata": {},
+     "outputs": [],
+     "source": [
+      "1+1"
+     ]
+    }
+   ],
+   "metadata": {},
+   "nbformat": 4,
+   "nbformat_minor": 0
+  }

--- a/tests/test_metadata_period.ipynb
+++ b/tests/test_metadata_period.ipynb
@@ -1,0 +1,64 @@
+{
+  "cells": [
+    {
+      "cell_type": "markdown",
+      "source": [
+        "This notebook tests that metadata keys with periods can be stripped."
+      ],
+      "metadata": {
+        "application/vnd.databricks.v1+cell": {
+          "title": "",
+          "showTitle": false,
+          "inputWidgets": {},
+          "nuid": "4006abf4-c940-4065-aa15-3772229cbe25"
+        }
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "1+1"
+      ],
+      "metadata": {
+        "application/vnd.databricks.v1+cell": {
+          "title": "",
+          "showTitle": false,
+          "inputWidgets": {},
+          "nuid": "5069d88c-a72a-40b8-acf5-258ee9649736"
+        }
+      },
+      "outputs": [
+        {
+          "output_type": "display_data",
+          "metadata": {
+            "application/vnd.databricks.v1+output": {
+              "datasetInfos": [],
+              "data": "<div class=\"ansiout\">Out[1]: 2</div>",
+              "removedWidgets": [],
+              "addedWidgets": {},
+              "type": "html",
+              "arguments": {}
+            }
+          },
+          "data": {
+            "text/html": [
+              "<style scoped>\n  .ansiout {\n    display: block;\n    unicode-bidi: embed;\n    white-space: pre-wrap;\n    word-wrap: break-word;\n    word-break: break-all;\n    font-family: \"Source Code Pro\", \"Menlo\", monospace;;\n    font-size: 13px;\n    color: #555;\n    margin-left: 4px;\n    line-height: 19px;\n  }\n</style>\n<div class=\"ansiout\">Out[1]: 2</div>"
+            ]
+          }
+        }
+      ],
+      "execution_count": 0
+    }
+  ],
+  "metadata": {
+    "application/vnd.databricks.v1+notebook": {
+      "notebookName": "test_metadata_period",
+      "dashboards": [],
+      "language": "python",
+      "widgets": {},
+      "notebookOrigID": 123456
+    }
+  },
+  "nbformat": 4,
+  "nbformat_minor": 0
+}


### PR DESCRIPTION
Fixes #143 by checking to see if the `key` passed to `pop_recursive` literally exists in `d`, prior to decomposing the key into nested levels. If it exists, it is stripped. If it doesn't, periods in the key will be interpreted as nesting level delimiters.