### PR TITLE
Strip out 'id' field from cells

### DIFF
--- a/nbstripout/_utils.py
+++ b/nbstripout/_utils.py
@@ -98,6 +98,10 @@ def strip_output(nb, keep_output, keep_count, extra_keys=''):
     for cell in _cells(nb):
         keep_output_this_cell = determine_keep_output(cell, keep_output)
 
+        # Remove cell IDs
+        if 'id' in cell:
+            cell['id'] = None
+
         # Remove the outputs, unless directed otherwise
         if 'outputs' in cell:
 


### PR DESCRIPTION
As described in issue #146, cell IDs are here to stay with notebook formats 4.5+. The code in the PR strips them out (no configuration option). It is working in my setup as a git filter (no other usage tested).