### PR TITLE
Add support for stripping init cells

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -227,6 +227,14 @@ whitespace ::
 
     nbstripout --strip-empty-cells
 
+Removing `init` cells
+++++++++++++++++++++
+
+By default ``nbstripout`` will keep cells with `init_cell: true` metadata. To disable
+this behavior use ::
+
+    nbstripout --strip-init-cells
+
 Keeping some output
 +++++++++++++++++++
 

--- a/nbstripout/_nbstripout.py
+++ b/nbstripout/_nbstripout.py
@@ -517,7 +517,7 @@ def main():
                 nb = read(input_stream, as_version=NO_CONVERT)
 
             nb = strip_output(nb, args.keep_output, args.keep_count, extra_keys, 
-                                    args.strip_empty_cells, args.strip_init_cells, _parse_size(args.max_size))
+                              args.strip_empty_cells, args.strip_init_cells, _parse_size(args.max_size))
 
             if args.dry_run:
                 output_stream.write('Dry run: would have stripped input from '

--- a/nbstripout/_nbstripout.py
+++ b/nbstripout/_nbstripout.py
@@ -516,7 +516,7 @@ def main():
                 warnings.simplefilter("ignore", category=UserWarning)
                 nb = read(input_stream, as_version=NO_CONVERT)
 
-            nb = strip_output(nb, args.keep_output, args.keep_count, extra_keys, 
+            nb = strip_output(nb, args.keep_output, args.keep_count, extra_keys,
                               args.strip_empty_cells, args.strip_init_cells, _parse_size(args.max_size))
 
             if args.dry_run:

--- a/nbstripout/_nbstripout.py
+++ b/nbstripout/_nbstripout.py
@@ -379,6 +379,8 @@ def main():
                         'from metadata, e.g. metadata.foo cell.metadata.bar')
     parser.add_argument('--strip-empty-cells', action='store_true',
                         help='Remove cells where `source` is empty or contains only whitepace')
+    parser.add_argument('--strip-init-cells', action='store_true',
+                        help='Remove cells with `init_cell: true` metadata (default: False)')
     parser.add_argument('--attributes', metavar='FILEPATH',
                         help='Attributes file to add the filter to (in '
                         'combination with --install/--uninstall), '
@@ -514,7 +516,8 @@ def main():
                 warnings.simplefilter("ignore", category=UserWarning)
                 nb = read(input_stream, as_version=NO_CONVERT)
 
-            nb = strip_output(nb, args.keep_output, args.keep_count, extra_keys, args.strip_empty_cells, _parse_size(args.max_size))
+            nb = strip_output(nb, args.keep_output, args.keep_count, extra_keys, 
+                                    args.strip_empty_cells, args.strip_init_cells, _parse_size(args.max_size))
 
             if args.dry_run:
                 output_stream.write('Dry run: would have stripped input from '

--- a/nbstripout/_utils.py
+++ b/nbstripout/_utils.py
@@ -56,14 +56,14 @@ def get_size(item):
         return len(str(item))
 
 
-def determine_keep_output(cell, default):
+def determine_keep_output(cell, default, strip_init_cells=False):
     """Given a cell, determine whether output should be kept
 
     Based on whether the metadata has "init_cell": true,
     "keep_output": true, or the tags contain "keep_output" """
     if 'metadata' not in cell:
         return default
-    if 'init_cell' in cell.metadata:
+    if 'init_cell' in cell.metadata and strip_init_cells:
         return bool(cell.metadata.init_cell)
 
     has_keep_output_metadata = 'keep_output' in cell.metadata
@@ -94,7 +94,7 @@ def strip_zeppelin_output(nb):
     return nb
 
 
-def strip_output(nb, keep_output, keep_count, extra_keys=[], strip_empty_cells=False, max_size=0):
+def strip_output(nb, keep_output, keep_count, extra_keys=[], strip_empty_cells=False, strip_init_cells=False, max_size=0):
     """
     Strip the outputs, execution count/prompt number and miscellaneous
     metadata from a notebook object, unless specified to keep either the outputs
@@ -125,7 +125,7 @@ def strip_output(nb, keep_output, keep_count, extra_keys=[], strip_empty_cells=F
         conditional = None
 
     for cell in _cells(nb, conditional):
-        keep_output_this_cell = determine_keep_output(cell, keep_output)
+        keep_output_this_cell = determine_keep_output(cell, keep_output, strip_init_cells)
 
         # Remove the outputs, unless directed otherwise
         if 'outputs' in cell:

--- a/nbstripout/_utils.py
+++ b/nbstripout/_utils.py
@@ -63,8 +63,8 @@ def determine_keep_output(cell, default, strip_init_cells=False):
     "keep_output": true, or the tags contain "keep_output" """
     if 'metadata' not in cell:
         return default
-    if 'init_cell' in cell.metadata and strip_init_cells:
-        return bool(cell.metadata.init_cell)
+    if 'init_cell' in cell.metadata:
+        return bool(cell.metadata.init_cell) and not strip_init_cells
 
     has_keep_output_metadata = 'keep_output' in cell.metadata
     keep_output_metadata = bool(cell.metadata.get('keep_output', False))

--- a/tests/test-strip-init-cells.t
+++ b/tests/test-strip-init-cells.t
@@ -1,0 +1,45 @@
+  $ cat ${TESTDIR}/test_strip_init_cells.ipynb | ${NBSTRIPOUT_EXE:-nbstripout} --strip-init-cells
+  {
+   "cells": [
+    {
+     "cell_type": "markdown",
+     "metadata": {},
+     "source": [
+      "This notebook tests that cells with `\"init_cell\": true` are stripped when the `--strip-init-cells` flag is passed in."
+     ]
+    },
+    {
+     "cell_type": "code",
+     "execution_count": null,
+     "metadata": {
+      "init_cell": true
+     },
+     "outputs": [],
+     "source": [
+      "1+1 # This cell has `\"init_cell:\" true`"
+     ]
+    }
+   ],
+   "metadata": {
+    "celltoolbar": "Edit Metadata",
+    "kernelspec": {
+     "display_name": "Python 2",
+     "language": "python",
+     "name": "python2"
+    },
+    "language_info": {
+     "codemirror_mode": {
+      "name": "ipython",
+      "version": 2
+     },
+     "file_extension": ".py",
+     "mimetype": "text/x-python",
+     "name": "python",
+     "nbconvert_exporter": "python",
+     "pygments_lexer": "ipython2",
+     "version": "2.7.11"
+    }
+   },
+   "nbformat": 4,
+   "nbformat_minor": 0
+  }

--- a/tests/test_strip_init_cells.ipynb
+++ b/tests/test_strip_init_cells.ipynb
@@ -1,0 +1,56 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This notebook tests that cells with `\"init_cell\": true` are stripped when the `--strip-init-cells` flag is passed in."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {
+    "collapsed": false,
+    "init_cell": true
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "2"
+      ]
+     },
+     "execution_count": 1,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "1+1 # This cell has `\"init_cell:\" true`"
+   ]
+  }
+ ],
+ "metadata": {
+  "celltoolbar": "Edit Metadata",
+  "kernelspec": {
+   "display_name": "Python 2",
+   "language": "python",
+   "name": "python2"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 2
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython2",
+   "version": "2.7.11"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 0
+}


### PR DESCRIPTION
As mentioned in #156 :

This PR adds a flag: `--strip-init-cells` which alters the current behavior to also remove outputs from init cells.

Reason:
I have a whole bunch of notebooks which have the `init_cell: true` metadata. This generates a nice default set of UI widgets as soon as the notebook is loaded. However, since this is generated automatically, I don't want all the widget output checked into my source repo. Right now, every time a user commits a change to the notebook, we have huge amounts of cell output from the init_cell cells.