### PR TITLE
Add an --drop-tagged-cells="some tags" Option

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -235,6 +235,17 @@ this behavior use ::
 
     nbstripout --strip-init-cells
 
+Removing entire cells
+++++++++++++++++++++
+
+In certain conditions it might be handy to remove not only the output, but the entire cell, e.g. when developing exercises.
+
+To drop all cells tagged with "solution" run:
+
+    nbstripout --drop-tagged-cells="solution"
+
+The option accepts a list of tags separated by whitespace.
+
 Keeping some output
 +++++++++++++++++++
 

--- a/nbstripout/_nbstripout.py
+++ b/nbstripout/_nbstripout.py
@@ -378,6 +378,8 @@ def main():
                         'from metadata, e.g. metadata.foo cell.metadata.bar')
     parser.add_argument('--drop-empty-cells', action='store_true',
                         help='Remove cells where `source` is empty or contains only whitepace')
+    parser.add_argument('--drop-tagged-cells', default='',
+                        help='Space separated list of cell-tags that remove an entire cell')
     parser.add_argument('--strip-init-cells', action='store_true',
                         help='Remove cells with `init_cell: true` metadata (default: False)')
     parser.add_argument('--attributes', metavar='FILEPATH',
@@ -469,8 +471,8 @@ def main():
                     warnings.simplefilter("ignore", category=UserWarning)
                     nb = read(f, as_version=NO_CONVERT)
 
-            nb = strip_output(nb, args.keep_output, args.keep_count, extra_keys,
-                              args.drop_empty_cells, args.strip_init_cells, _parse_size(args.max_size))
+            nb = strip_output(nb, args.keep_output, args.keep_count, extra_keys, args.drop_empty_cells,
+                              args.drop_tagged_cells.split(), args.strip_init_cells, _parse_size(args.max_size))
 
             if args.dry_run:
                 output_stream.write(f'Dry run: would have stripped {filename}\n')
@@ -515,8 +517,8 @@ def main():
                 warnings.simplefilter("ignore", category=UserWarning)
                 nb = read(input_stream, as_version=NO_CONVERT)
 
-            nb = strip_output(nb, args.keep_output, args.keep_count, extra_keys,
-                              args.drop_empty_cells, args.strip_init_cells, _parse_size(args.max_size))
+            nb = strip_output(nb, args.keep_output, args.keep_count, extra_keys, args.drop_empty_cells,
+                              args.drop_tagged_cells.split(), args.strip_init_cells, _parse_size(args.max_size))
 
             if args.dry_run:
                 output_stream.write('Dry run: would have stripped input from '

--- a/tests/test-drop-tagged-cells.t
+++ b/tests/test-drop-tagged-cells.t
@@ -1,0 +1,192 @@
+  $ cat ${TESTDIR}/test_drop_tagged_cells.ipynb | ${NBSTRIPOUT_EXE:-nbstripout}
+  {
+   "cells": [
+    {
+     "cell_type": "code",
+     "execution_count": null,
+     "metadata": {},
+     "outputs": [],
+     "source": [
+      "print('This cell will always be kept')"
+     ]
+    },
+    {
+     "cell_type": "markdown",
+     "metadata": {},
+     "source": [
+      "# This cell will also be kept"
+     ]
+    },
+    {
+     "cell_type": "code",
+     "execution_count": null,
+     "metadata": {
+      "tags": [
+       "test2"
+      ]
+     },
+     "outputs": [],
+     "source": [
+      "# This Code cell will stay"
+     ]
+    },
+    {
+     "cell_type": "code",
+     "execution_count": null,
+     "metadata": {
+      "tags": [
+       "test"
+      ]
+     },
+     "outputs": [],
+     "source": [
+      "# This is a Code Cell will be removed"
+     ]
+    },
+    {
+     "cell_type": "code",
+     "execution_count": null,
+     "metadata": {},
+     "outputs": [],
+     "source": [
+      "\n",
+      " \n",
+      "    "
+     ]
+    },
+    {
+     "cell_type": "markdown",
+     "metadata": {
+      "tags": [
+       "test"
+      ]
+     },
+     "source": [
+      "This is markdown and will be removed"
+     ]
+    },
+    {
+     "cell_type": "markdown",
+     "metadata": {
+      "tags": [
+       "test2"
+      ]
+     },
+     "source": [
+      "This is Markdown and will be kept"
+     ]
+    },
+    {
+     "cell_type": "code",
+     "execution_count": null,
+     "metadata": {},
+     "outputs": [],
+     "source": []
+    }
+   ],
+   "metadata": {
+    "kernelspec": {
+     "display_name": "Python 3 (ipykernel)",
+     "language": "python",
+     "name": "python3"
+    },
+    "language_info": {
+     "codemirror_mode": {
+      "name": "ipython",
+      "version": 3
+     },
+     "file_extension": ".py",
+     "mimetype": "text/x-python",
+     "name": "python",
+     "nbconvert_exporter": "python",
+     "pygments_lexer": "ipython3",
+     "version": "3.9.6"
+    }
+   },
+   "nbformat": 4,
+   "nbformat_minor": 4
+  }
+  $ cat ${TESTDIR}/test_drop_tagged_cells.ipynb | ${NBSTRIPOUT_EXE:-nbstripout} --drop-tagged-cells="test"
+  {
+   "cells": [
+    {
+     "cell_type": "code",
+     "execution_count": null,
+     "metadata": {},
+     "outputs": [],
+     "source": [
+      "print('This cell will always be kept')"
+     ]
+    },
+    {
+     "cell_type": "markdown",
+     "metadata": {},
+     "source": [
+      "# This cell will also be kept"
+     ]
+    },
+    {
+     "cell_type": "code",
+     "execution_count": null,
+     "metadata": {
+      "tags": [
+       "test2"
+      ]
+     },
+     "outputs": [],
+     "source": [
+      "# This Code cell will stay"
+     ]
+    },
+    {
+     "cell_type": "code",
+     "execution_count": null,
+     "metadata": {},
+     "outputs": [],
+     "source": [
+      "\n",
+      " \n",
+      "    "
+     ]
+    },
+    {
+     "cell_type": "markdown",
+     "metadata": {
+      "tags": [
+       "test2"
+      ]
+     },
+     "source": [
+      "This is Markdown and will be kept"
+     ]
+    },
+    {
+     "cell_type": "code",
+     "execution_count": null,
+     "metadata": {},
+     "outputs": [],
+     "source": []
+    }
+   ],
+   "metadata": {
+    "kernelspec": {
+     "display_name": "Python 3 (ipykernel)",
+     "language": "python",
+     "name": "python3"
+    },
+    "language_info": {
+     "codemirror_mode": {
+      "name": "ipython",
+      "version": 3
+     },
+     "file_extension": ".py",
+     "mimetype": "text/x-python",
+     "name": "python",
+     "nbconvert_exporter": "python",
+     "pygments_lexer": "ipython3",
+     "version": "3.9.6"
+    }
+   },
+   "nbformat": 4,
+   "nbformat_minor": 4
+  }

--- a/tests/test_drop_tagged_cells.ipynb
+++ b/tests/test_drop_tagged_cells.ipynb
@@ -1,0 +1,115 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "This cell will always be kept\n"
+     ]
+    }
+   ],
+   "source": [
+    "print('This cell will always be kept')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# This cell will also be kept"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {
+    "tags": [
+     "test2"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "# This Code cell will stay"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {
+    "tags": [
+     "test"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "# This is a Code Cell will be removed"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "\n",
+    " \n",
+    "    "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "tags": [
+     "test"
+    ]
+   },
+   "source": [
+    "This is markdown and will be removed"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "tags": [
+     "test2"
+    ]
+   },
+   "source": [
+    "This is Markdown and will be kept"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.6"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}


### PR DESCRIPTION
Hi, 

the present pull request adds an apparatus to skip entire cells based on a list of tags that can be passed as command line argument.

It might be unappropriate to suggest such a feature to a tool, that indicates in its name that it strips output only. Having said that, there is already an option that strips empty cells entirely. Therefore I leave the decision up to you :)

My use case is, that I create lots of exercise notebooks for students. Clearing the solution is manual and error-prone labor. With this patch applied a simple makefile can convert solutions to exercises and (unrelated to this tool) convert solutions to a pdf.

Tests pass an I added an additional one.
