### PR TITLE
Bump CI actions/checkout to v3 and actions/setup-python to v4

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,13 +11,13 @@ jobs:
         python-version: ['3.6', '3.7', '3.8', '3.9', '3.10']
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install Python 3.6 dependencies
-      if: ${{ matrix.python-version == '3.6' }}
+      if: matrix.python-version == '3.6'
       run: python -m pip install 'traitlets<5' 'nbformat==5.1.3'
     - name: Install dependencies
       run: |


### PR DESCRIPTION
Split-out PR following https://github.com/kynan/nbstripout/pull/169#discussion_r985213823.