### PR TITLE
Fix shellcheck SC2006 in `pre-commit` script

### DIFF
--- a/pre-commit
+++ b/pre-commit
@@ -13,12 +13,12 @@ else
    # Initial commit: diff against an empty tree object
    against=4b825dc642cb6eb9a060e54bf8d69288fbee4904
 fi
- 
+
 # Find notebooks to be committed
 (
 IFS='
 '
-NBS=`git diff-index -z --cached $against --name-only | grep '.ipynb$' | uniq`
+NBS=$(git diff-index -z --cached $against --name-only | grep '.ipynb$' | uniq)
 
 for NB in $NBS ; do
     echo "Removing outputs from $NB"


### PR DESCRIPTION
Use `$(...)` notation instead of legacy backticks `...`.

Split-out PR following https://github.com/kynan/nbstripout/pull/169#discussion_r985213752.