### PR TITLE
feat: add option to keep output style

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -320,9 +320,21 @@ Additional metadata to be stripped can be configured via either
           cell.metadata.tags
           cell.metadata.init_cell'
 
-*   the ``--extra-keys`` flag, which takes a string as an argument, e.g. ::
+*   the ``--extra-keys`` flag, which takes a space-delimited string as an argument, e.g. ::
 
         --extra-keys "metadata.celltoolbar cell.metadata.heading_collapsed"
+
+You can keep certain metadata with either
+
+*   ``git config (--global/--system) filter.nbstripout.keepmetadatakeys``, e.g. ::
+
+        git config --global filter.nbstripout.keepmetadatakeys '
+          cell.metadata.collapsed
+          cell.metadata.scrolled'
+
+*   the ``--keep-metadata-keys`` flag, which takes a space-delimited string as an argument, e.g. ::
+
+        --keep-metadata-keys "cell.metadata.collapsed cell.metadata.scrolled"
 
 Note: Previous versions of Jupyter used ``metadata.kernel_spec`` for kernel
 metadata. Prefer stripping ``kernelspec`` entirely: only stripping some

--- a/nbstripout/_nbstripout.py
+++ b/nbstripout/_nbstripout.py
@@ -376,6 +376,9 @@ def main():
     parser.add_argument('--extra-keys', default='',
                         help='Space separated list of extra keys to strip '
                         'from metadata, e.g. metadata.foo cell.metadata.bar')
+    parser.add_argument('--keep-metadata-keys', default='',
+                        help='Space separated list of metadata keys to keep'
+                        ', e.g. metadata.foo cell.metadata.bar')
     parser.add_argument('--drop-empty-cells', action='store_true',
                         help='Remove cells where `source` is empty or contains only whitepace')
     parser.add_argument('--drop-tagged-cells', default='',
@@ -445,6 +448,16 @@ def main():
         pass
 
     extra_keys.extend(args.extra_keys.split())
+
+    try:
+        keep_metadata_keys = check_output(
+            (git_config if args._system or args._global else ['git', 'config']) + ['filter.nbstripout.keepmetadatakeys'],
+            universal_newlines=True
+        ).strip().split()
+    except (CalledProcessError, FileNotFoundError):
+        keep_metadata_keys = []
+    keep_metadata_keys.extend(args.keep_metadata_keys.split())
+    extra_keys = [i for i in extra_keys if i not in keep_metadata_keys]
 
     # Wrap input/output stream in UTF-8 encoded text wrapper
     # https://stackoverflow.com/a/16549381

--- a/nbstripout/_utils.py
+++ b/nbstripout/_utils.py
@@ -149,7 +149,6 @@ def strip_output(nb, keep_output, keep_count, extra_keys=[], drop_empty_cells=Fa
         if 'execution_count' in cell and not keep_count:
             cell['execution_count'] = None
 
-        # Always remove some metadata
         for field in keys['cell']:
             pop_recursive(cell, field)
     return nb

--- a/tests/e2e_notebooks/test_keep_metadata_keys.ipynb
+++ b/tests/e2e_notebooks/test_keep_metadata_keys.ipynb
@@ -1,0 +1,27 @@
+{
+  "cells": [
+   {
+    "cell_type": "markdown",
+    "metadata": {
+     "scrolled": true
+    },
+    "source": [
+     "This notebook tests that using \"--keep-metadata-keys\" works as expected."
+    ]
+   },
+   {
+    "cell_type": "code",
+    "execution_count": null,
+    "metadata": {
+     "collapsed": true
+    },
+    "outputs": [],
+    "source": [
+     "1+1"
+    ]
+   }
+  ],
+  "metadata": {},
+  "nbformat": 4,
+  "nbformat_minor": 0
+ }

--- a/tests/e2e_notebooks/test_keep_metadata_keys.ipynb.expected
+++ b/tests/e2e_notebooks/test_keep_metadata_keys.ipynb.expected
@@ -1,0 +1,27 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "scrolled": true
+   },
+   "source": [
+    "This notebook tests that using \"--keep-metadata-keys\" works as expected."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "1+1"
+   ]
+  }
+ ],
+ "metadata": {},
+ "nbformat": 4,
+ "nbformat_minor": 0
+}

--- a/tests/test_diff.ipynb
+++ b/tests/test_diff.ipynb
@@ -4,7 +4,8 @@
    "cell_type": "code",
    "execution_count": 5,
    "metadata": {
-    "collapsed": false
+    "collapsed": false,
+    "scrolled": true
    },
    "outputs": [],
    "source": [

--- a/tests/test_end_to_end.py
+++ b/tests/test_end_to_end.py
@@ -22,6 +22,7 @@ TEST_CASES = [
     ("test_metadata.ipynb", "test_metadata_keep_output.ipynb.expected", ["--keep-output"]),
     ("test_metadata.ipynb", "test_metadata_keep_output_keep_count.ipynb.expected", ["--keep-output", "--keep-count"]),
     ("test_metadata_notebook.ipynb", "test_metadata_notebook.ipynb", []),
+    ("test_keep_metadata_keys.ipynb", "test_keep_metadata_keys.ipynb.expected", ["--keep-metadata-keys", "cell.metadata.scrolled cell.metadata.collapsed metadata.a"]),
     ("test_metadata_period.ipynb", "test_metadata_period.ipynb.expected", ["--extra-keys", "cell.metadata.application/vnd.databricks.v1+cell metadata.application/vnd.databricks.v1+notebook"]),
     ("test_strip_init_cells.ipynb", "test_strip_init_cells.ipynb.expected", ["--strip-init-cells"]),
     ("test_nbformat2.ipynb", "test_nbformat2.ipynb.expected", []),

--- a/tests/test_git_integration.py
+++ b/tests/test_git_integration.py
@@ -171,3 +171,32 @@ def test_git_diff_extrakeys(pytester: pytest.Pytester):
   ],
 """.splitlines())
     assert len(r.outlines) == 13  # 12 lines + new line at end
+
+
+def test_git_diff_keepmetadatakeys(pytester: pytest.Pytester):
+    pytester.run('git', 'init')
+    pytester.run('git', 'config', '--local', 'filter.nbstripout.keepmetadatakeys', 'cell.metadata.scrolled metadata.foo.bar')
+    pytester.run('nbstripout', '--install')
+
+    r = pytester.run('git', 'diff', '--no-index', NOTEBOOKS_FOLDER / "test_diff.ipynb", NOTEBOOKS_FOLDER / "test_diff_different_extrakeys.ipynb")
+    assert r.ret == 1
+    r.stdout.fnmatch_lines(r"""index*
+--- *test_diff.ipynb*
++++ *test_diff_different_extrakeys.ipynb*
+@@ -3,20 +3,17 @@
+   {
+    "cell_type": "code",
+    "execution_count": null,
+-   "metadata": {
+-    "scrolled": true
+-   },
++   "metadata": {},
+    "outputs": [],
+    "source": [
+-    "print(\"aou\")"
++    "print(\"aou now it is different\")"
+    ]
+   }
+  ],
+""".splitlines())
+    assert len(r.outlines) == 28  # 12 lines + new line at end


### PR DESCRIPTION
with `nbstripout --keep-metadata-keys` or git config key `filter.nbstripout.keepmetadatakeys`.

closes #78