### PR TITLE
Update README.md with git-filter-repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,7 +204,7 @@ from existing notebooks. This invocation operates on all ipynb files in the repo
     #!/usr/bin/env bash
     # get lint-history with callback from https://github.com/newren/git-filter-repo/pull/542
     ./lint-history.py --relevant 'return filename.endswith(b".ipynb")' --callback '
-    import json,warnings,nbformat
+    import json, warnings, nbformat
     from nbstripout import strip_output
     from nbformat.reader import NotJSONError
     try:

--- a/README.md
+++ b/README.md
@@ -212,7 +212,7 @@ from existing notebooks. This invocation operates on all ipynb files in the repo
             warnings.simplefilter("ignore", category=UserWarning)
             notebook = nbformat.reads(blob.data, as_version=nbformat.NO_CONVERT)
         # customize to your needs
-        strip_output(notebook, keep_output=False, keep_count=False, keep_id=False, extra_keys=["metadata.widgets","metadata.execution","cell.attachments"], drop_empty_cells=True, drop_tagged_cells=[],strip_init_cells=False, max_size=0)
+        strip_output(notebook, keep_output=False, keep_count=False, keep_id=False, extra_keys=["metadata.widgets","metadata.execution","cell.attachments"], drop_empty_cells=True,  drop_tagged_cells=[],strip_init_cells=False, max_size=0)
         old_len=len(blob.data)
         blob.data = (nbformat.writes(notebook) + "\n").encode("utf-8")
         if old_len!=len(blob.data):

--- a/README.md
+++ b/README.md
@@ -210,7 +210,7 @@ from existing notebooks. This invocation operates on all ipynb files in the repo
     try:
         with warnings.catch_warnings():
             warnings.simplefilter("ignore", category=UserWarning)
-            notebook = nbformat.reads(blob.data,as_version=nbformat.NO_CONVERT)
+            notebook = nbformat.reads(blob.data, as_version=nbformat.NO_CONVERT)
         # customize to your needs
         strip_output(notebook, keep_output=False, keep_count=False, keep_id=False, extra_keys=["metadata.widgets","metadata.execution","cell.attachments"], drop_empty_cells=True, drop_tagged_cells=[],strip_init_cells=False, max_size=0)
         old_len=len(blob.data)

--- a/README.md
+++ b/README.md
@@ -197,23 +197,30 @@ Note that you need to uninstall with the same flags:
 ### Apply retroactively
 
 `nbstripout` can be used to rewrite an existing Git repository using
-`git filter-branch` to strip output from existing notebooks. This invocation
-uses `--index-filter` and operates on all ipynb-files in the repo: :
+`git filter-repo` to strip output from existing notebooks. This invocation
+operates on all ipynb-files in the repo: :
 
-    git filter-branch -f --index-filter '
-        git checkout -- :*.ipynb
-        find . -name "*.ipynb" -exec nbstripout "{}" +
-        git add . --ignore-removal
+```sh
+    #!/usr/bin/env bash
+    # get lint-history with callback from https://github.com/newren/git-filter-repo/pull/542
+    ./lint-history.py --relevant 'return filename.endswith(b".ipynb")' --callback '
+    import json,warnings,nbformat
+    from nbstripout import strip_output
+    from nbformat.reader import NotJSONError
+    try:
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", category=UserWarning)
+            notebook = nbformat.reads(blob.data,as_version=nbformat.NO_CONVERT)
+        # customize to your needs
+        strip_output(notebook, keep_output=False, keep_count=False, keep_id=False, extra_keys=["metadata.widgets","metadata.execution","cell.attachments"], drop_empty_cells=True, drop_tagged_cells=[],strip_init_cells=False, max_size=0)
+        old_len=len(blob.data)
+        blob.data = (nbformat.writes(notebook) + "\n").encode("utf-8")
+        if old_len!=len(blob.data):
+            print(change.blob_id,change.filename,old_len,len(blob.data))
+    except NotJSONError as exc:
+         print("ERROR",type(exc),change.blob_id,filename)
     '
-
-If the repository is large and the notebooks are in a subdirectory it will run
-faster with `git checkout -- :<subdir>/*.ipynb`. You will get a warning for
-commits that do not contain any notebooks, which can be suppressed by piping
-stderr to `/dev/null`.
-
-This is a potentially slower but simpler invocation using `--tree-filter`:
-
-    git filter-branch -f --tree-filter 'find . -name "*.ipynb" -exec nbstripout "{}" +'
+```
 
 ### Removing empty cells
 

--- a/README.md
+++ b/README.md
@@ -215,8 +215,8 @@ from existing notebooks. This invocation operates on all ipynb files in the repo
         strip_output(notebook, keep_output=False, keep_count=False, keep_id=False, extra_keys=["metadata.widgets","metadata.execution","cell.attachments"], drop_empty_cells=True,  drop_tagged_cells=[],strip_init_cells=False, max_size=0)
         old_len = len(blob.data)
         blob.data = (nbformat.writes(notebook) + "\n").encode("utf-8")
-        if old_len!=len(blob.data):
-            print(change.blob_id,change.filename,old_len,len(blob.data))
+        if old_len != len(blob.data):
+            print(change.blob_id, change.filename, old_len, len(blob.data))
     except NotJSONError as exc:
          print("ERROR",type(exc),change.blob_id,filename)
     '

--- a/README.md
+++ b/README.md
@@ -213,7 +213,7 @@ from existing notebooks. This invocation operates on all ipynb files in the repo
             notebook = nbformat.reads(blob.data, as_version=nbformat.NO_CONVERT)
         # customize to your needs
         strip_output(notebook, keep_output=False, keep_count=False, keep_id=False, extra_keys=["metadata.widgets","metadata.execution","cell.attachments"], drop_empty_cells=True,  drop_tagged_cells=[],strip_init_cells=False, max_size=0)
-        old_len=len(blob.data)
+        old_len = len(blob.data)
         blob.data = (nbformat.writes(notebook) + "\n").encode("utf-8")
         if old_len!=len(blob.data):
             print(change.blob_id,change.filename,old_len,len(blob.data))

--- a/README.md
+++ b/README.md
@@ -217,8 +217,8 @@ from existing notebooks. This invocation operates on all ipynb files in the repo
         blob.data = (nbformat.writes(notebook) + "\n").encode("utf-8")
         if old_len != len(blob.data):
             print(change.blob_id, change.filename, old_len, len(blob.data))
-    except NotJSONError as exc:
-         print("ERROR",type(exc),change.blob_id,filename)
+    except NotJSONError as e:
+         print("ERROR", type(e), change.blob_id, filename)
     '
 ```
 

--- a/README.md
+++ b/README.md
@@ -197,8 +197,8 @@ Note that you need to uninstall with the same flags:
 ### Apply retroactively
 
 `nbstripout` can be used to rewrite an existing Git repository using
-`git filter-repo` to strip output from existing notebooks. This invocation
-operates on all ipynb-files in the repo: :
+[`git filter-repo`](https://github.com/newren/git-filter-repo) to strip output
+from existing notebooks. This invocation operates on all ipynb files in the repo:
 
 ```sh
     #!/usr/bin/env bash


### PR DESCRIPTION
Did the minimal changes to the lint-history example on git-filter-repo to allow using nbstripout while keeping performance by never spawning a second interpreter.
See https://github.com/kynan/nbstripout/issues/193
Tested with 2GB repo, went down to 50MB.