### PR TITLE
Adds --verify

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,13 @@ Do a dry run and only list which files would have been stripped:
 
     nbstripout --dry-run FILE.ipynb [FILE2.ipynb ...]
 
+or
+
+Do a verification run, which works like dry run but will fail
+if any files would have been stripped:
+
+    nbstripout --verify FILE.ipynb [FILE2.ipynb ...]
+
 Operate on all `.ipynb` files in the current directory and subdirectories
 recursively:
 

--- a/nbstripout/_nbstripout.py
+++ b/nbstripout/_nbstripout.py
@@ -508,8 +508,8 @@ def main():
         try:
             with io.open(filename, 'r+', encoding='utf8', newline='') as f:
                 out = output_stream if args.textconv or args.dry_run else f
-                any_local_change = process_notebook(f, out, args, extra_keys, filename)
-                any_change = any_change or any_local_change
+                if process_notebook(f, out, args, extra_keys, filename):
+                    any_change = True
 
         except nbformat.reader.NotJSONError:
             print(f"No valid notebook detected in '{filename}'", file=sys.stderr)

--- a/nbstripout/_nbstripout.py
+++ b/nbstripout/_nbstripout.py
@@ -331,27 +331,39 @@ def status(git_config, install_location=INSTALL_LOCATION_LOCAL, verbose=False):
         return 1
 
 def process_notebook(input_stream, output_stream, args, extra_keys, filename='input from stdin'):
+    any_change = False
     if args.mode == 'zeppelin':
         nb = json.load(input_stream, object_pairs_hook=collections.OrderedDict)
+        nb_str_orig = json.dumps(nb, indent=2)
         nb_stripped = strip_zeppelin_output(nb)
+
+        nb_str_stripped = json.dumps(nb_stripped, indent=2)
+        if nb_str_orig != nb_str_stripped:
+            any_change = True
+
         if args.dry_run:
             output_stream.write(f'Dry run: would have stripped {filename}\n')
-            return
+            return any_change
         if output_stream.seekable():
             output_stream.seek(0)
             output_stream.truncate()
         json.dump(nb_stripped, output_stream, indent=2)
         output_stream.write('\n')
         output_stream.flush()
-        return
+        return any_change
+
     with warnings.catch_warnings():
         warnings.simplefilter("ignore", category=UserWarning)
         nb = nbformat.read(input_stream, as_version=nbformat.NO_CONVERT)
 
+    nb_start_str = json.dumps(nb, indent=2)
     nb = strip_output(nb, args.keep_output, args.keep_count, args.keep_id,
                         extra_keys, args.drop_empty_cells,
                         args.drop_tagged_cells.split(), args.strip_init_cells,
                         _parse_size(args.max_size))
+    nb_end_str = json.dumps(nb, indent=2)
+    if nb_start_str != nb_end_str:
+        any_change = True
 
     if args.dry_run:
         output_stream.write(f'Dry run: would have stripped {filename}\n')
@@ -363,7 +375,7 @@ def process_notebook(input_stream, output_stream, args, extra_keys, filename='in
             warnings.simplefilter("ignore", category=UserWarning)
             nbformat.write(nb, output_stream)
         output_stream.flush()
-
+    return any_change
 
 def main():
     parser = ArgumentParser(epilog=__doc__, formatter_class=RawDescriptionHelpFormatter)
@@ -383,6 +395,8 @@ def main():
                       'repository and configuration summary if installed')
     task.add_argument('--version', action='store_true',
                       help='Print version')
+    parser.add_argument("--verify", action="store_true",
+                      help="Return a non-zero exit code if any files were changed, Implies --dry-run")
     parser.add_argument('--keep-count', action='store_true',
                         help='Do not strip the execution count/prompt number')
     parser.add_argument('--keep-output', action='store_true',
@@ -427,6 +441,11 @@ def main():
     parser.add_argument('files', nargs='*', help='Files to strip output from')
     args = parser.parse_args()
     git_config = ['git', 'config']
+
+    if args.verify:
+        if not args.dry_run:
+            print("Running in verify mode, setting --dry-run")
+            args.dry_run = True
 
     if args._system:
         git_config.append('--system')
@@ -483,6 +502,7 @@ def main():
     input_stream = io.TextIOWrapper(sys.stdin.buffer, encoding='utf-8') if sys.stdin else None
     output_stream = io.TextIOWrapper(sys.stdout.buffer, encoding='utf-8', newline='')
 
+    any_change = False
     for filename in args.files:
         if not (args.force or filename.endswith('.ipynb') or filename.endswith('.zpln')):
             continue
@@ -490,7 +510,9 @@ def main():
         try:
             with io.open(filename, 'r+', encoding='utf8', newline='') as f:
                 out = output_stream if args.textconv or args.dry_run else f
-                process_notebook(f, out, args, extra_keys, filename)
+                any_local_change = process_notebook(f, out, args, extra_keys, filename)
+                any_change = any_change or any_local_change
+
         except nbformat.reader.NotJSONError:
             print(f"No valid notebook detected in '{filename}'", file=sys.stderr)
             raise SystemExit(1)
@@ -504,7 +526,11 @@ def main():
 
     if not args.files and input_stream:
         try:
-            process_notebook(input_stream, output_stream, args, extra_keys)
+            any_local_change = process_notebook(input_stream, output_stream, args, extra_keys)
+            any_change = any_change or any_local_change
         except nbformat.reader.NotJSONError:
             print('No valid notebook detected on stdin', file=sys.stderr)
             raise SystemExit(1)
+        
+    if args.verify and any_change:
+        raise SystemExit(1)

--- a/nbstripout/_nbstripout.py
+++ b/nbstripout/_nbstripout.py
@@ -442,10 +442,8 @@ def main():
     args = parser.parse_args()
     git_config = ['git', 'config']
 
-    if args.verify:
-        if not args.dry_run:
-            print("Running in verify mode, setting --dry-run")
-            args.dry_run = True
+    if args.verify and not args.dry_run:
+        args.dry_run = True
 
     if args._system:
         git_config.append('--system')

--- a/nbstripout/_nbstripout.py
+++ b/nbstripout/_nbstripout.py
@@ -396,7 +396,7 @@ def main():
     task.add_argument('--version', action='store_true',
                       help='Print version')
     parser.add_argument("--verify", action="store_true",
-                      help="Return a non-zero exit code if any files were changed, Implies --dry-run")
+                        help="Return a non-zero exit code if any files were changed, Implies --dry-run")
     parser.add_argument('--keep-count', action='store_true',
                         help='Do not strip the execution count/prompt number')
     parser.add_argument('--keep-output', action='store_true',

--- a/nbstripout/_nbstripout.py
+++ b/nbstripout/_nbstripout.py
@@ -355,13 +355,13 @@ def process_notebook(input_stream, output_stream, args, extra_keys, filename='in
         warnings.simplefilter("ignore", category=UserWarning)
         nb = nbformat.read(input_stream, as_version=nbformat.NO_CONVERT)
 
-    nb_start = copy.deepcopy(nb)
+    nb_orig = copy.deepcopy(nb)
     nb = strip_output(nb, args.keep_output, args.keep_count, args.keep_id,
                         extra_keys, args.drop_empty_cells,
                         args.drop_tagged_cells.split(), args.strip_init_cells,
                         _parse_size(args.max_size))
-    nb_end = copy.deepcopy(nb)
-    if nb_start != nb_end:
+
+    if nb_orig != nb:
         any_change = True
 
     if args.dry_run:

--- a/tests/test_end_to_end.py
+++ b/tests/test_end_to_end.py
@@ -120,10 +120,7 @@ def test_dry_run_stdin(input_file: str, extra_args: List[str], verify: bool):
         output = pc.stdout
 
     assert output == expected
-    if verify:
-        assert pc.returncode == 1
-    else:
-        assert pc.returncode == 0
+    assert pc.returncode == 1 if verify else 0
 
 
 @pytest.mark.parametrize("input_file, extra_args", DRY_RUN_CASES)

--- a/tests/test_end_to_end.py
+++ b/tests/test_end_to_end.py
@@ -70,7 +70,7 @@ def test_end_to_end_stdin(input_file: str, expected_file: str, args: List[str], 
 
     if verify:
         # When using stin, the dry run flag is disregarded.
-        assert pc.returncode == 1 if input_ != expected else 0
+        assert pc.returncode == (1 if input_ != expected else 0)
     else:
         assert output == expected
         assert pc.returncode == 0
@@ -97,11 +97,14 @@ def test_end_to_end_file(input_file: str, expected_file: str, args: List[str], t
     output = pc.stdout.strip()
     if verify:
         if expected != input_:
+            assert "Dry run: would have stripped" in output
             assert pc.returncode == 1
 
         # Since verify implies --dry-run, we make sure the file is not modified
-        # In other words, that the output == input, INSTEAD of output == expected
-        assert output == input_
+        with open(NOTEBOOKS_FOLDER / input_file, mode="r") as f:
+            output_ = f.read()
+
+        assert output_ == input_
     else:
         assert pc.returncode == 0
         assert not pc.stdout and p.read_text() == expected
@@ -120,7 +123,7 @@ def test_dry_run_stdin(input_file: str, extra_args: List[str], verify: bool):
         output = pc.stdout
 
     assert output == expected
-    assert pc.returncode == 1 if verify else 0
+    assert pc.returncode == (1 if verify else 0)
 
 
 @pytest.mark.parametrize("input_file, extra_args", DRY_RUN_CASES)

--- a/tests/test_end_to_end.py
+++ b/tests/test_end_to_end.py
@@ -104,7 +104,7 @@ def test_end_to_end_file(input_file: str, expected_file: str, args: List[str], t
 
         # Since verify implies --dry-run, we make sure the file is not modified
         # In other words, that the output == input, INSTEAD of output == expected
-        output == input_
+        assert output == input_
     else:
         assert pc.returncode == 0
         assert not pc.stdout and p.read_text() == expected

--- a/tests/test_end_to_end.py
+++ b/tests/test_end_to_end.py
@@ -106,9 +106,8 @@ def test_end_to_end_file(input_file: str, expected_file: str, args: List[str], t
         # In other words, that the output == input, INSTEAD of output == expected
         output == input_
     else:
-        output = p.read_text()
         assert pc.returncode == 0
-        assert output == expected
+        assert not pc.stdout and p.read_text() == expected
 
 
 @pytest.mark.parametrize("input_file, extra_args", DRY_RUN_CASES)

--- a/tests/test_end_to_end.py
+++ b/tests/test_end_to_end.py
@@ -122,13 +122,12 @@ def test_dry_run_stdin(input_file: str, extra_args: List[str], verify: bool):
             args.append("--verify")
         pc = run(args, stdin=f, stdout=PIPE, universal_newlines=True)
         output = pc.stdout
-        exit_code = pc.returncode
 
     assert output == expected
     if verify:
-        assert exit_code == 1
+        assert pc.returncode == 1
     else:
-        assert exit_code == 0
+        assert pc.returncode == 0
 
 
 @pytest.mark.parametrize("input_file, extra_args", DRY_RUN_CASES)

--- a/tests/test_end_to_end.py
+++ b/tests/test_end_to_end.py
@@ -70,10 +70,7 @@ def test_end_to_end_stdin(input_file: str, expected_file: str, args: List[str], 
 
     if verify:
         # When using stin, the dry run flag is disregarded.
-        if input_ != expected:
-            assert pc.returncode == 1
-        else:
-            assert pc.returncode == 0
+        assert pc.returncode == 1 if input_ != expected else 0
     else:
         assert output == expected
         assert pc.returncode == 0

--- a/tests/test_end_to_end.py
+++ b/tests/test_end_to_end.py
@@ -138,11 +138,10 @@ def test_dry_run_args(input_file: str, extra_args: List[str], verify: bool):
         args.append("--verify")
     pc = run(args, stdout=PIPE, universal_newlines=True)
     output = pc.stdout
-    exit_code = pc.returncode
 
     assert expected_regex.match(output)
     if verify:
-        assert exit_code == 1
+        assert pc.returncode == 1
 
 
 @pytest.mark.parametrize("input_file, expected_errs, extra_args", ERR_OUTPUT_CASES)


### PR DESCRIPTION

Discussed here #153

The idea is to have a cli flag that works as --dry-run BUT returns a status 1 if any change would have been made on the files.

This PR is still a work in progress, right now its compatible with the behavior of the rest of the flags but I think we need to add a test case that verifies its behavior directly (2 files, one that gets changed, one that doesnt and make sure they exit with the correct error) an additional test I can think of is that no file should return status 1 if it has already been stripped (so .... step 1, verify it returns status 1, make sure no changes are made; step 2 run bstripout, step 3 verify that it returns status 0 on the modified file).
